### PR TITLE
Parameterisation of stokes drift and significant wave height if not a…

### DIFF
--- a/opendrift/models/physics_methods.py
+++ b/opendrift/models/physics_methods.py
@@ -16,6 +16,7 @@
 
 import logging
 import numpy as np
+from math import sqrt
 from opendrift.readers.basereader import pyproj
 
 
@@ -182,6 +183,71 @@ class PhysicsMethods(object):
         else:
             logging.debug('Advecting with Stokes drift (%s to %s m/s)' %
                       (s.min(), s.max()))
+
+    def wave_stokes_drift_parameterised(self, wind = (0, 0), fetch = None):
+        """
+        Parameterise stokes drift based on pre calculated tables and fetch.
+        """
+        Wf       = {}
+        Wf[5000] = (0.0173,0.0160,0.0152,0.0145,0.0139,0.0135,
+                    0.0132,0.0129,0.0126,0.0124,0.0122,0.0121,
+                    0.0119,0.0118,0.0117,0.0116,0.0114,0.0113,
+                    0.0112,0.0112,0.0111,0.0110,0.0109,0.0109,
+                    0.0108,0.0107,0.0106,0.0106,0.0106,0.0105)
+
+        Wf[25000] = (0.0173,0.0197,0.0201,0.0185,0.0181,0.0176,
+                     0.0171,0.0167,0.0164,0.0160,0.0158,0.0155,
+                     0.0153,0.0151,0.0149,0.0147,0.0146,0.0144,
+                     0.0143,0.0142,0.0140,0.0139,0.0138,0.0137,
+                     0.0136,0.0135,0.0135,0.0134,0.0133,0.0132)
+
+        Wf[50000] = (0.0173,0.0197,0.0210,0.0216,0.0201,0.0194,
+                     0.0190,0.0186,0.0183,0.0179,0.0176,0.0173,
+                     0.0171,0.0168,0.0166,0.0164,0.0162,0.0160,
+                     0.0159,0.0157,0.0156,0.0155,0.0153,0.0152,
+                     0.0151,0.0150,0.0149,0.0148,0.0147,0.0146)
+
+        windSpeed = int(sqrt(wind[0]**2 + wind[1]**2))
+        if windSpeed > 30: windSpeed = 30
+        
+        stokes_drift_x_velocity = \
+            Wf.get(fetch, Wf[5000])[windSpeed] * wind[0]
+        
+        stokes_drift_y_velocity = \
+            Wf.get(fetch, Wf[5000])[windSpeed] * wind[1]
+
+        return stokes_drift_x_velocity, stokes_drift_y_velocity
+
+    def wave_significant_height_parameterised(self, wind = (0, 0), fetch = None):
+        """
+        Parameterise significant wave height based on pre calculated tables and fetch.
+        """
+        Sw       = {}
+        Sw[5000] = (0.030,0.077,0.124,0.170,0.216,0.263,
+                    0.311,0.360,0.409,0.459,0.509,0.560,
+                    0.612,0.664,0.716,0.771,0.823,0.876,
+                    0.932,0.987,1.041,1.095,1.152,1.210,
+                    1.265,1.319,1.375,1.434,1.494,1.552)
+
+        Sw[25000] = (0.030,0.122,0.251,0.336,0.442,0.546,
+                     0.650,0.753,0.856,0.959,1.063,1.168,
+                     1.273,1.379,1.486,1.593,1.702,1.811,
+                     1.920,2.030,2.142,2.254,2.366,2.478,
+                     2.592,2.707,2.822,2.936,3.051,3.166)
+
+        Sw[50000] = (0.030,0.122,0.274,0.474,0.591,0.724,
+                     0.873,1.021,1.168,1.314,1.460,1.606,
+                     1.752,1.898,2.045,2.192,2.340,2.489,
+                     2.639,2.789,2.940,3.092,3.244,3.397,
+                     3.551,3.706,3.862,4.017,4.173,4.330)
+
+        windSpeed = int(sqrt(wind[0]**2 + wind[1]**2))
+        if windSpeed > 30: windSpeed = 30
+
+        wave_significant_height = \
+            Sw.get(fetch, Sw[5000])[windSpeed]
+
+        return wave_significant_height
 
     def resurface_elements(self, minimum_depth):
         # Keep surfacing elements in water column as default,

--- a/opendrift/models/physics_methods.py
+++ b/opendrift/models/physics_methods.py
@@ -184,7 +184,7 @@ class PhysicsMethods(object):
             logging.debug('Advecting with Stokes drift (%s to %s m/s)' %
                       (s.min(), s.max()))
 
-    def wave_stokes_drift_parameterised(self, wind = (0, 0), fetch = None):
+    def wave_stokes_drift_parameterised(self, wind, fetch):
         """
         Parameterise stokes drift based on pre calculated tables and fetch.
         """
@@ -211,14 +211,14 @@ class PhysicsMethods(object):
         if windSpeed > 30: windSpeed = 30
         
         stokes_drift_x_velocity = \
-            Wf.get(fetch, Wf[5000])[windSpeed] * wind[0]
+            Wf.get(fetch, Wf[25000])[windSpeed] * wind[0]
         
         stokes_drift_y_velocity = \
-            Wf.get(fetch, Wf[5000])[windSpeed] * wind[1]
+            Wf.get(fetch, Wf[25000])[windSpeed] * wind[1]
 
         return stokes_drift_x_velocity, stokes_drift_y_velocity
 
-    def wave_significant_height_parameterised(self, wind = (0, 0), fetch = None):
+    def wave_significant_height_parameterised(self, wind, fetch):
         """
         Parameterise significant wave height based on pre calculated tables and fetch.
         """
@@ -245,7 +245,7 @@ class PhysicsMethods(object):
         if windSpeed > 30: windSpeed = 30
 
         wave_significant_height = \
-            Sw.get(fetch, Sw[5000])[windSpeed]
+            Sw.get(fetch, Sw[25000])[windSpeed]
 
         return wave_significant_height
 


### PR DESCRIPTION
Simple methods for selecting pre calculated stokes drift velocity and significant wave height based on wind speed and fetch. Tables range from 0 to 30 m/s. Fetch 5000m, 25000m and 50000m.

Just a nice feature to have if working with limited input. The feature was added to opendrift in order to easier compare results with the SMHI driftmodel SeaTrackWeb.

**Parameterised with fetch 25000m:**
![animate_25000m_fetch](https://user-images.githubusercontent.com/6288935/28720198-bb08383c-73ac-11e7-8d20-8b311b83371b.gif)

**No parameterisation**
![animate_no_parameterisation](https://user-images.githubusercontent.com/6288935/28720237-d7425f82-73ac-11e7-8028-0913ab72429c.gif)

