### PR TITLE
Use custom oil defined in "sample_oils" repo in OilLibray

### DIFF
--- a/opendrift/models/openoil.py
+++ b/opendrift/models/openoil.py
@@ -141,6 +141,7 @@ class OpenOil(OpenDriftSimulation):
             try:
                 from oil_library import _get_db_session
                 from oil_library.models import Oil, ImportedRecord
+                from oil_library import sample_oils
             except:
                 raise ImportError(
                     'NOAA oil library must be installed from: '
@@ -159,6 +160,9 @@ class OpenOil(OpenDriftSimulation):
                 self.oiltypes = session.query(Oil.name).all()
             self.oiltypes = sorted([o[0] for o in self.oiltypes])
             self.oiltypes = [ot for ot in self.oiltypes if ot not in self.duplicate_oils]
+            # append names of "sample_oils" of OilLibrary
+            for so in sample_oils._sample_oils.keys() :
+                self.oiltypes.append(unicode(so)) # using unicode for consistency
         else:
             # Read oil properties from file
             self.oiltype_file = os.path.dirname(os.path.realpath(__file__)) + \
@@ -701,7 +705,12 @@ class OpenOil(OpenDriftSimulation):
                             ADIOS_Oil.name == oiltype)
                 ADIOS_ids = [oil.adios_oil_id for oil in oils]
                 if len(ADIOS_ids) == 0:
-                    raise ValueError('Oil type "%s" not found in NOAA database' % oiltype)
+                    try :
+                        # try to load oiltype even if it wasnt found in the official "oils" database instead of raising error directly
+                        # as it could still be present in sample_oils - there is probably a nicer way to do this
+                        self.oiltype = get_oil_props(oiltype) 
+                    except : 
+                        raise ValueError('Oil type "%s" not found in NOAA database' % oiltype)
                 elif len(ADIOS_ids) == 1:
                     self.oiltype = get_oil_props(oiltype)
                 else:


### PR DESCRIPTION
The OilLibrary packages allows the definition of custom oils, without having to rebuild the entire database in 
***\OilLibrary\oil_library\sample_oils

One can thus create a new <.py> file in that folder, populate the json dictionary with custom oils specs. After adding the new custom oil name the __init__.py of the same directory, one can then use the new oil, like any other one of the library e.g.

`import oil_library`
`oil_obj = oil_library.get_oil('DIESEL FUEL OIL (ALASKA)') # oil record in official database`
`custom_oil_obj = oil_library.get_oil('my_custom_oil') # oil record in official database```

For now, opendrift will crash, if that custom oil, previously added to the OilLibrary, is specified when seeding elements

`o.seed_elements( ****oiltype = 'my_custom_oil', *****`

My workaround was to append the sample_oils to `self.oiltypes`  - in openoil.py(__init__), then allow to try 
`self.oiltype = get_oil_props(oiltype) ` even if no ADIOS_ids was found - in openoil.py(set_oiltype).