### PR TITLE
Read Vtransform from native ROMS files

### DIFF
--- a/opendrift/readers/reader_ROMS_native.py
+++ b/opendrift/readers/reader_ROMS_native.py
@@ -279,14 +279,14 @@ class Reader(BaseReader):
                     self.Dataset.variables['h'][:]
 
                 Htot = self.sea_floor_depth_below_sea_level
-                self.z_rho_tot = depth.sdepth(Htot, self.hc, self.Cs_r)
+                self.z_rho_tot = depth.sdepth(Htot, self.hc, self.Cs_r, Vtransform = np.asarray(self.Dataset['Vtransform']) )
 
             if has_xarray is False:
                 indxgrid, indygrid = np.meshgrid(indx, indy)
                 H = self.sea_floor_depth_below_sea_level[indygrid, indxgrid]
             else:
                 H = self.sea_floor_depth_below_sea_level[indy, indx]
-            z_rho = depth.sdepth(H, self.hc, self.Cs_r)
+            z_rho = depth.sdepth(H, self.hc, self.Cs_r, Vtransform = np.asarray(self.Dataset['Vtransform']) )
             # Element indices must be relative to extracted subset
             indx_el = np.clip(indx_el - indx.min(), 0, z_rho.shape[2]-1)
             indy_el = np.clip(indy_el - indy.min(), 0, z_rho.shape[1]-1)


### PR DESCRIPTION
Instead of assuming Vtransform = 1 as per default in sdepth()

Using `np.asarray(self.Dataset['Vtransform'])` seems to work whether the "Dataset" is loaded using netCDF4 or xarray.