### PR TITLE
set_config() now raises error immediately if config-values are outsid…

### DIFF
--- a/opendrift/models/basemodel.py
+++ b/opendrift/models/basemodel.py
@@ -303,6 +303,7 @@ class OpenDriftSimulation(PhysicsMethods):
 
         d = self.configobj
         ds = self.configobj.configspec
+        default, minval, maxval, opt = self.get_configspec_default_min_max(key)
         for i, s in enumerate(key.split(':')):
             if s not in d:
                 self.list_configspec()
@@ -312,6 +313,10 @@ class OpenDriftSimulation(PhysicsMethods):
                     value = float(value)
                 if ds[s][0:5] == 'integ' and value is not None:
                     value = int(value)
+                if isinstance(value, float) or isinstance(value, int):
+                    if (minval is not None and value<minval) or (maxval is not None and value>maxval):
+                        raise ValueError('Value of %s (%s) is outside allowed interval: (%s - %s)' %
+                                         (key, value, minval, maxval))
                 d[s] = value
             else:
                 d = d[s]
@@ -361,7 +366,7 @@ class OpenDriftSimulation(PhysicsMethods):
         v = validate.Validator()
         default = v.get_default_value(cs[s])
         datatype = cs[s].split('(')[0]
-        if datatype in ['float', 'integer']:
+        if datatype in ['float', 'integer'] and 'min' in cs[s] and 'max' in cs[s]:
             minimum = cs[s].split('min=')[-1].split(',')[0]
             maximum = cs[s].split('max=')[-1].split(',')[0]
             if datatype == 'float':

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -121,6 +121,13 @@ class TestRun(unittest.TestCase):
         with self.assertRaises(ValueError):
             o.run(steps=3, time_step=timedelta(minutes=15))
 
+    def test_invalid_config(self):
+        o = OceanDrift(loglevel=20)
+        with self.assertRaises(ValueError):
+            o.set_config('seed:number_of_elements', 0)
+        o.set_config('seed:number_of_elements', 100)
+        self.assertEqual(o.get_config('seed:number_of_elements'), 100)
+
     def test_runge_kutta(self):
         number = 50
         # With Euler


### PR DESCRIPTION
…e allowed range. Previously these were adjusted before error was raised, giving erroneous result if within try-except clause