### PR TITLE
Making vertical mixing scheme much faster and simpler, by using numpy…

### DIFF
--- a/examples/example_oil_verticalmixing.py
+++ b/examples/example_oil_verticalmixing.py
@@ -41,7 +41,9 @@ o.plot(linecolor='z', fast=True)
 o.plot_property('z')
 o.plot_oil_budget()
 o.animation(fast=True)
+o.animate_vertical_distribution()
 
 #%%
 # .. image:: /gallery/animations/example_oil_verticalmixing_0.gif
+# .. image:: /gallery/animations/example_oil_verticalmixing_1.gif
 

--- a/opendrift/models/oceandrift.py
+++ b/opendrift/models/oceandrift.py
@@ -418,10 +418,12 @@ class OceanDrift(OpenDriftSimulation):
 
         if depths is not None:
             axk.plot(np.mean(self.environment_profiles['ocean_vertical_diffusivity'], 1), self.environment_profiles['z'])
+            xmax = self.environment_profiles['ocean_vertical_diffusivity'].max()
         else:
             axk.plot(K, z, 'k.')
+            xmax = K.max()
         axk.set_ylim([maxdepth, 0])
-        axk.set_xlim([0, self.environment_profiles['ocean_vertical_diffusivity'].max()*1.1])
+        axk.set_xlim([0, xmax*1.1])
         axk.set_ylabel('Depth [m]')
         axk.set_xlabel('Vertical diffusivity [$m^2/s$]')
 

--- a/tests/integration/test_oillibrary.py
+++ b/tests/integration/test_oillibrary.py
@@ -140,14 +140,14 @@ class TestOil(unittest.TestCase):
                     meanlon = 4.81742
                 elif oil == 'SMORBUKK KONDENSAT' and windspeed == 8:
                     fraction_dispersed = 0.086
-                    fraction_submerged = 0.302
-                    fraction_evaporated = 0.491
-                    meanlon = 4.816
+                    fraction_submerged = 0.354
+                    fraction_evaporated = 0.479
+                    meanlon = 4.812
                 elif oil == 'SKRUGARD' and windspeed == 8:
                     fraction_dispersed = 0.133
                     fraction_submerged = 0.328
                     fraction_evaporated = 0.187
-                    meanlon = 4.827
+                    meanlon = 4.825
                 else:
                     fraction_dispersed = -1  # not defined
                 self.assertAlmostEqual(actual_dispersed[-1],
@@ -177,7 +177,7 @@ class TestOil(unittest.TestCase):
         actual_dispersed = b['mass_dispersed']/b['mass_total']
         self.assertAlmostEqual(actual_dispersed[-1], 0)
         self.assertIsNone(np.testing.assert_array_almost_equal(
-            o.elements.lon[0:3], [4.799928, 4.80109 , 4.810431], 3))
+            o.elements.lon[0:3], [4.803, 4.815 , 4.819], 3))
 
     @unittest.skipIf(has_oil_library is False,
                      'NOAA OilLibrary is needed')

--- a/tests/integration/test_physics.py
+++ b/tests/integration/test_physics.py
@@ -138,7 +138,7 @@ class TestPhysics(unittest.TestCase):
         #o.plot_vertical_distribution()
         #o.animation_profile()
         # Check minimum depth
-        self.assertAlmostEqual(o.elements.z.min(), -46.3, 1)
+        self.assertAlmostEqual(o.elements.z.min(), -46.2, 1)
         #######################################################
 
     def test_vertical_mixing_plantoil_windonly(self):
@@ -177,7 +177,7 @@ class TestPhysics(unittest.TestCase):
         o.run(duration=timedelta(hours=2),
               time_step_output=1800, time_step=1800)
         #o.plot_vertical_distribution()
-        self.assertAlmostEqual(o.elements.z.min(), -42.6, 1)
+        self.assertAlmostEqual(o.elements.z.min(), -42.1, 1)
         ########################################################
 
     def test_verticalmixing_schemes(self):
@@ -199,9 +199,9 @@ class TestPhysics(unittest.TestCase):
             o.run(duration=timedelta(hours=2), time_step=900)
 
             if scheme == 'environment':  # presently this is fallback
-                self.assertAlmostEqual(o.elements.z.min(), -41.37, 1)
+                self.assertAlmostEqual(o.elements.z.min(), -41.5, 1)
             elif scheme == 'windspeed_Large1994':
-                self.assertAlmostEqual(o.elements.z.min(), -41.37, 1)
+                self.assertAlmostEqual(o.elements.z.min(), -41.5, 1)
             elif scheme == 'windspeed_Sundby1983':
                 self.assertAlmostEqual(o.elements.z.min(), -36.7, 1)
             elif scheme == 'zero':

--- a/tests/integration/test_run.py
+++ b/tests/integration/test_run.py
@@ -327,17 +327,18 @@ class TestRun(unittest.TestCase):
 
         o1.run(steps=20, time_step=300, time_step_output=1800,
                export_buffer_length=10, outfile='verticalmixing.nc')
-        self.assertAlmostEqual(o1.history['z'].min(), -38.1, 1)
+        self.assertAlmostEqual(o1.history['z'].min(), -38.7, 1)
         self.assertAlmostEqual(o1.history['z'].max(), 0.0, 1)
         os.remove('verticalmixing.nc')
 
     def test_vertical_mixing_profiles(self):
         # Testing an isolated mixing timestep
+
         cases = [  # Some cases with expected outcome
                 {'vt': 0, 'K': 0, 'K_below': .01, 'T': 60, # No mixing
                     'zmin': -10, 'zmax': -10, 'zmean': -10},
                 {'vt': -.005, 'K': 0, 'K_below': .01, 'T': 60, # Sinking
-                    'zmin': -73.1, 'zmax': -21.6, 'zmean': -50.2},
+                    'zmin': -74.0, 'zmax': -21.4, 'zmean': -50.2},
                 {'vt': 0, 'K': .01, 'K_below': .01, 'T': 60, # Mixing
                     'zmin': -39.8, 'zmax': -0.1, 'zmean': -14.5},
                 {'vt': .005, 'K': .01, 'K_below': .01, 'T': 60, # Mixing and rising
@@ -345,8 +346,9 @@ class TestRun(unittest.TestCase):
                 {'vt': -0.005, 'K': .01, 'K_below': .01, 'T': 60, # Mixing and sinking
                     'zmin': -75.8, 'zmax': -20.7, 'zmean': -48.1},
                 {'vt': 0, 'K': .02, 'K_below': .001, 'T': 60,  # Mixing in mixed layer
-                    'zmin': -20.8, 'zmax': -0.06, 'zmean': -10.3},
+                    'zmin': -22.8, 'zmax': -0.1, 'zmean': -9.8},
                 ]
+
         N=100
         z = np.arange(0, -30, -2)
         time = datetime.now()
@@ -357,7 +359,7 @@ class TestRun(unittest.TestCase):
             o.set_config('drift:vertical_mixing', True)
             o.set_config('vertical_mixing:diffusivitymodel', 'environment')
             o.set_config('vertical_mixing:timestep', case['T'])
-            o.seed_elements(lon=4, lat=60, z=-10, time=time, number=100,
+            o.seed_elements(lon=4, lat=60, z=-10, time=time, number=N,
                             terminal_velocity=case['vt'])
             o.time = time
             o.time_step = timedelta(hours=2)

--- a/tests/integration/test_run_3d.py
+++ b/tests/integration/test_run_3d.py
@@ -59,8 +59,8 @@ class TestRun(unittest.TestCase):
         self.assertEqual(o.num_elements_deactivated(), 0)
         self.assertAlmostEqual(o.elements.lat[0], 71.16, 1)
         #self.assertAlmostEqual(o.elements.z.min(), -41.92, 1)  # With past ROMS-masking
-        self.assertAlmostEqual(o.elements.z.min(), -46.4, 1)
-        self.assertAlmostEqual(o.elements.z.max(), -0.23, 1)
+        self.assertAlmostEqual(o.elements.z.min(), -46.7, 1)
+        self.assertAlmostEqual(o.elements.z.max(), -0.4, 1)
         #self.assertAlmostEqual(o.elements.lon.max(), 14.949, 2)
         self.assertAlmostEqual(o.elements.lon.max(), 14.87, 2)
 


### PR DESCRIPTION
….gradient before the inner loop, instead of calculating differentials manually at each iteration. Slightly different output from mixing tests, which had to be updated, but results are also probably more accurate than before.