### PR TITLE
Allow for constant 'ocean_vertical_diffusivity' values

### DIFF
--- a/opendrift/models/oceandrift.py
+++ b/opendrift/models/oceandrift.py
@@ -107,7 +107,7 @@ class OceanDrift(OpenDriftSimulation):
                 vertical_mixing = boolean(default=False)
             [vertical_mixing]
                 timestep = float(min=0.1, max=3600, default=60.)
-                diffusivitymodel = option('environment', 'zero', 'stepfunction', 'windspeed_Sundby1983', 'windspeed_Large1994', 'gls_tke', default='environment')
+                diffusivitymodel = option('environment', 'zero', 'stepfunction', 'windspeed_Sundby1983', 'windspeed_Large1994', 'gls_tke','constant', default='environment')
                 TSprofiles = boolean(default=False)
                 '''
         self._add_configstring(configspec_oceandrift)
@@ -279,6 +279,9 @@ class OceanDrift(OpenDriftSimulation):
                 # Using higher vertical resolution when analytical
                 self.environment_profiles['z'] = -np.arange(0, 50)
                 Kprofiles = self.get_diffusivity_profile('windspeed_Large1994')
+        elif diffusivity_model == 'constant':
+            self.logger.debug('Using constant diffusivity specified by fallback_values[''ocean_vertical_diffusivity''] = %s m2.s-1' % (self.fallback_values['ocean_vertical_diffusivity']))
+            Kprofiles = self.environment_profiles['ocean_vertical_diffusivity'] # keep constant value for ocean_vertical_diffusivity
         else:
             self.logger.debug('Using functional expression for diffusivity')
             # Using higher vertical resolution when analytical


### PR DESCRIPTION
Adding a new option for `vertical_mixing:diffusivitymodel` = 'constant'. where the fallback value is used.