### PR TITLE
Unwrap get_variables_wrapper (impl) + get_variables_derived so that these are not called back from sub-class

### DIFF
--- a/opendrift/readers/basereader/continuous.py
+++ b/opendrift/readers/basereader/continuous.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 import numpy as np
 from .variables import Variables
 from .consts import vector_pairs_xy
@@ -15,14 +16,23 @@ class ContinuousReader(Variables):
 
         :py:mod:`opendrift.readers`
     """
+
+    @abstractmethod
+    def get_variables(self, variables, time=None, x=None, y=None, z=None):
+        """
+        Obtain and return values of the requested variables at all positions
+        (x, y, z) closest to given time.
+
+        Returns:
+
+            Dictionary with arrays of length len(x) with values at exact positions x, y and z.
+        """
+
     def _get_variables_interpolated_(self, variables, profiles,
                                    profiles_depth, time,
                                    reader_x, reader_y, z):
 
-        env = self._get_variables_impl_(variables, profiles,
-                                            profiles_depth,
-                                            time,
-                                            reader_x, reader_y, z)
+        env = self.get_variables(variables, time, reader_x, reader_y, z)
 
         logger.debug('Fetched env-before')
         env_profiles = None

--- a/opendrift/readers/interpolation/structured.py
+++ b/opendrift/readers/interpolation/structured.py
@@ -5,6 +5,7 @@ import scipy.ndimage as ndimage
 from scipy.interpolate import interp1d, LinearNDInterpolator
 
 from .interpolators import Nearest2DInterpolator, fill_NaN_towards_seafloor, horizontal_interpolation_methods, vertical_interpolation_methods
+from opendrift.readers.basereader import variables
 
 import logging
 logger = logging.getLogger(__name__)
@@ -35,6 +36,8 @@ class ReaderBlock():
         # Mask any extremely large values, e.g. if missing netCDF _Fill_value
         filled_variables = set()
         for var in self.data_dict:
+            self.data_dict[var] = variables.Variables.__check_variable_array__(var, self.data_dict[var])
+
             if isinstance(self.data_dict[var], np.ma.core.MaskedArray):
                 self.data_dict[var] = np.ma.masked_outside(
                     np.ma.masked_invalid(self.data_dict[var]), -1E+9, 1E+9)

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,7 @@
 testpaths = tests
 norecursedirs = wps benchmarks test_data
 addopts = --benchmark-disable
+
+markers =
+    slow: marks tests as slow
+    veryslow: marks tests as very slow

--- a/tests/integration/test_readers.py
+++ b/tests/integration/test_readers.py
@@ -586,11 +586,11 @@ class TestReaders(unittest.TestCase):
 
     def test_valid_minmax(self):
         """Check that invalid values are replaced with fallback."""
-        o = OceanDrift(loglevel=50)
-        from opendrift.readers import basereader
-        minval = basereader.standard_names['x_wind']['valid_min']
+        o = OceanDrift()
+        from opendrift.readers.basereader import variables
+        minval = variables.standard_names['x_wind']['valid_min']
         # Setting valid_min to -5, to check that replacement works
-        basereader.standard_names['x_wind']['valid_min'] = -5
+        variables.standard_names['x_wind']['valid_min'] = -5
         reader_wind = reader_netCDF_CF_generic.Reader(o.test_data_folder() +
                     '16Nov2015_NorKyst_z_surface/arome_subset_16Nov2015.nc')
         o.add_reader(reader_wind)
@@ -600,23 +600,23 @@ class TestReaders(unittest.TestCase):
         o.set_config('environment:fallback:land_binary_mask', 0)
         o.seed_elements(lon=4, lat=60, time=reader_wind.start_time)
         o.run(steps=1)
-        basereader.standard_names['x_wind']['valid_min'] = minval  # reset
+        variables.standard_names['x_wind']['valid_min'] = minval  # reset
         w = o.get_property('x_wind')[0][0]
         self.assertAlmostEqual(w, 2.0, 1)
 
     def test_valid_minmax_nanvalues(self):
-        from opendrift.readers import basereader
+        from opendrift.readers.basereader import variables
         # Reducing max current speed to test masking
-        maxval = basereader.standard_names['x_sea_water_velocity']['valid_max']
-        basereader.standard_names['x_sea_water_velocity']['valid_max'] = .1
-        o = OceanDrift(loglevel=50)
+        maxval = variables.standard_names['x_sea_water_velocity']['valid_max']
+        variables.standard_names['x_sea_water_velocity']['valid_max'] = .1
+        o = OceanDrift()
         o.set_config('environment:fallback:land_binary_mask', 0)
         norkyst = reader_netCDF_CF_generic.Reader(o.test_data_folder() + '14Jan2016_NorKyst_z_3d/NorKyst-800m_ZDEPTHS_his_00_3Dsubset.nc')
         o.add_reader(norkyst)
 
         o.seed_elements(lon=4.95, lat=62, number=100, time=norkyst.start_time)
         o.run(steps=2)
-        basereader.standard_names['x_sea_water_velocity']['valid_max'] = maxval  # reset
+        variables.standard_names['x_sea_water_velocity']['valid_max'] = maxval  # reset
         u = o.get_property('x_sea_water_velocity')[0]
         self.assertAlmostEqual(u.max(), .1, 2)  # Some numerical error allowed
 


### PR DESCRIPTION
- reader: unwrap get_variables_impl and get_variables_derive
- pytest: register slow and veryslow marks
