### PR TITLE
When importing a subset of elements from a saved simulation, elements…

### DIFF
--- a/opendrift/export/io_netcdf.py
+++ b/opendrift/export/io_netcdf.py
@@ -312,7 +312,7 @@ def import_file(self, filename, times=None, elements=None):
         if var in self.ElementType.variables:
             kwargs[var] = self.history[var][
                 np.arange(len(index_of_last)), index_of_last]
-    kwargs['ID'] = elements + 1
+    kwargs['ID'] = np.arange(len(elements)) + 1
     self.elements = self.ElementType(**kwargs)
     self.elements_deactivated = self.ElementType()
 

--- a/opendrift/models/basemodel.py
+++ b/opendrift/models/basemodel.py
@@ -2843,7 +2843,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
                   background=None, bgalpha=.5, vmin=None, vmax=None, drifter=None,
                   skip=5, scale=10, color=False, clabel=None,
                   colorbar=True, cmap=None, density=False, show_elements=True,
-                  show_trajectories=False, hide_landmask=False,
+                  show_trajectories=False, trajectory_alpha=.1, hide_landmask=False,
                   density_pixelsize_m=1000, unitfactor=1, lcs=None,
                   surface_only=False, markersize=20, origin_marker=None,
                   legend=None, legend_loc='best', fps=10, lscale=None, fast=False, **kwargs):
@@ -2965,7 +2965,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
             y[z<0] = np.nan
 
         if show_trajectories is True:
-            ax.plot(x, y, color='gray', alpha=.1, transform = gcrs)
+            ax.plot(x, y, color='gray', alpha=trajectory_alpha, transform = gcrs)
 
         if color is not False and show_elements is True:
             if isinstance(color, str):


### PR DESCRIPTION
… are numbered from 0, to avoid problem with animation and deactivated elements. Transparency (alpha) of trajectories on animations may now be determined by user.