### PR TITLE
Config option *drift:lift_to_seafloor* is replaced by *general:seaflo…

### DIFF
--- a/examples/example_seafloor_interaction.py
+++ b/examples/example_seafloor_interaction.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""
+Seafloor interaction
+=====================
+"""
+
+#%%
+# This example demonstrates the three possibilities for
+# interaction of particles with seafloor:
+# - 'previous': particles are moved back to previous location
+# - 'deactivate': particles are deactivated
+# - 'lift_to_seafloor': particles are lifted vertically to seafloor level
+#
+# This is controlled by the config setting:
+# o.set_config('general:seafloor_action', <action>)
+
+
+from datetime import timedelta
+from opendrift.readers import reader_netCDF_CF_generic
+from opendrift.models.oceandrift import OceanDrift
+from opendrift.readers import reader_oscillating
+
+
+# readers
+o = OceanDrift(loglevel=50)
+reader_norkyst = reader_netCDF_CF_generic.Reader(o.test_data_folder() + '14Jan2016_NorKyst_z_3d/NorKyst-800m_ZDEPTHS_his_00_3Dsubset.nc')
+reader_osc = reader_oscillating.Reader('x_sea_water_velocity', amplitude=10, period_seconds=3600)
+
+runs = []
+seafloor_actions = ['previous', 'deactivate', 'lift_to_seafloor']
+
+for seafloor_action in seafloor_actions:
+
+    o = OceanDrift(loglevel=50)  # Set loglevel to 0 for debug information
+    o.max_speed = 10
+
+    o.add_reader([reader_osc, reader_norkyst])
+
+    o.set_config('drift:horizontal_diffusivity', 0)
+    o.set_config('environment:constant:y_sea_water_velocity', 0)
+    o.set_config('environment:constant:land_binary_mask', 0)
+    o.set_config('general:use_auto_landmask', False)
+    o.set_config('general:seafloor_action', seafloor_action)
+
+    # Seeding some particles 50m above seafloor
+    o.seed_elements(lon=4.2, lat=62.0, z='seafloor+50',
+                    radius=7000, number=200, time=reader_norkyst.start_time)
+
+    o.run(duration=timedelta(hours=2), time_step=120)
+    runs.append(o)
+
+
+runs[0].animation(fast=False, compare=runs[1:], legend=seafloor_actions,
+                  vmin=0, vmax=300, background='sea_floor_depth_below_sea_level')
+#%%
+# .. image:: /gallery/animations/example_seafloor_interaction_0.gif
+
+#%%
+# For the run with 'lift_to_seafloor', we see that
+# elements have been lifted vertically
+runs[2].plot_property('z')

--- a/history.rst
+++ b/history.rst
@@ -3,6 +3,11 @@ History
 
 Next release
 -----------------------------
+* Config option ``drift:lift_to_seafloor`` is replaced by ``general:seafloor_action``, analoguos to ``general:coastline_action``.
+  Available options are ``none``, ``deactivate``, ``lift_to_seafloor`` as well as new option ``previous`` - moving elements back to previous position.
+* New method ``get_trajectory_lengths`` to calculate length and speeds along trajectories
+* Basemodel class does not anymore have a projection, internal coordinates are now always lon, lat
+* Color of ocean and landmask may now be overridden in plot- and animation methods with new input variables ``land_color`` and ``ocean_color``. A new input dictionary ``text`` allows map annotations.
 * opendrift-landmask-data only loads mask once for each python process,
   reducing memory usage and improves performance where you run opendrift
   multiple times in the same script and process.

--- a/opendrift/models/oceandrift.py
+++ b/opendrift/models/oceandrift.py
@@ -121,8 +121,9 @@ class OceanDrift(OpenDriftSimulation):
             'drift:tabularised_stokes_drift_fetch': {'type': 'enum', 'enum': ['5000', '25000', '50000'], 'default': '25000',
                 'level': self.CONFIG_LEVEL_ADVANCED, 'description':
                 'The fetch length when using tabularised Stokes drift.'},
-            'drift:lift_to_seafloor': {'type': 'bool', 'default': True,
-                'description': 'If True, elements hitting/penetrating seafloor, are lifted to seafloor height. The alternative (False) is to deactivate elements).',
+            'general:seafloor_action': {'type': 'enum', 'default': 'lift_to_seafloor',
+                'enum': ['none', 'lift_to_seafloor', 'deactivate', 'previous'],
+                'description': '"deactivate": elements are deactivated; "lift_to_seafloor": elements are lifted to seafloor level; "previous": elements are moved back to previous position; "none"; seafloor is ignored.',
                 'level': self.CONFIG_LEVEL_ADVANCED},
             'drift:truncate_ocean_model_below_m': {'type': 'float', 'default': None,
                 'min': 0, 'max': 10000, 'units': 'm',

--- a/opendrift/models/physics_methods.py
+++ b/opendrift/models/physics_methods.py
@@ -674,24 +674,12 @@ class PhysicsMethods:
                 env['sea_floor_depth_below_sea_level'].astype('float32')
         return sea_floor_depth
 
-    def lift_elements_to_seafloor(self):
-        '''Lift any elements which are below seafloor'''
-
-        if 'sea_floor_depth_below_sea_level' not in self.priority_list:
-            return
-        sea_floor_depth = self.sea_floor_depth()
-        below = self.elements.z < -sea_floor_depth
-        if self.get_config('drift:lift_to_seafloor') is True:
-            self.elements.z[below] = -sea_floor_depth[below]
-        else:
-            self.deactivate_elements(below, reason='seafloor')
 
 def wind_drag_coefficient(windspeed):
     '''Large and Pond (1981), J. Phys. Oceanog., 11, 324-336.'''
     Cd = 0.0012*np.ones(len(windspeed))
     Cd[windspeed > 11] = 0.001*(0.49 + 0.065*windspeed[windspeed > 11])
     return Cd
-
 
 def windspeed_from_stress_polyfit(wind_stress):
     '''Inverting Large and Pond (1981) using polyfit'''

--- a/tests/models/test_run.py
+++ b/tests/models/test_run.py
@@ -681,7 +681,7 @@ class TestRun(unittest.TestCase):
         o.set_config('seed:droplet_diameter_max_subsea', 0.001)
         o.seed_elements(lon, lat, z=[-5000, -100], time=reader_norkyst.start_time,
                         density=1000, number=2)
-        o.set_config('drift:lift_to_seafloor', False)  # This time we deactivate
+        o.set_config('general:seafloor_action', 'deactivate')  # This time we deactivate
         o.set_config('drift:vertical_mixing', True)
 
         o.set_config('vertical_mixing:timestep', 1)  # s


### PR DESCRIPTION
…or_action*. New option *previous* moves elements hitting seafloor back to previous position. This is illustrated by new example example_seafloor_interaction.py