### PR TITLE
reader_netCDF_CF_generic: bugfix for lazy loading with coordinates in decreasing order

### DIFF
--- a/opendrift/readers/reader_netCDF_CF_generic.py
+++ b/opendrift/readers/reader_netCDF_CF_generic.py
@@ -367,8 +367,8 @@ class Reader(BaseReader, StructuredReader):
                 x = np.mod(x, 360)  # Shift x/lons to 0-360 
             elif self.lon_range() == '-180to180':
                 x = np.mod(x + 180, 360) - 180 # Shift x/lons to -180-180
-        indx = np.floor(np.abs(x-self.x[0])/self.delta_x).astype(int) + clipped
-        indy = np.floor(np.abs(y-self.y[0])/self.delta_y).astype(int) + clipped
+        indx = np.floor(np.abs(x-self.x[0])/self.delta_x-clipped).astype(int) + clipped
+        indy = np.floor(np.abs(y-self.y[0])/self.delta_y-clipped).astype(int) + clipped
         buffer = self.buffer  # Adding buffer, to cover also future positions of elements
         indy = np.arange(np.max([0, indy.min()-buffer]),
                          np.min([indy.max()+buffer, self.numy]))

--- a/opendrift/readers/reader_netCDF_CF_generic.py
+++ b/opendrift/readers/reader_netCDF_CF_generic.py
@@ -367,8 +367,8 @@ class Reader(BaseReader, StructuredReader):
                 x = np.mod(x, 360)  # Shift x/lons to 0-360 
             elif self.lon_range() == '-180to180':
                 x = np.mod(x + 180, 360) - 180 # Shift x/lons to -180-180
-        indx = np.floor((x-self.xmin)/self.delta_x).astype(int) + clipped
-        indy = np.floor((y-self.ymin)/self.delta_y).astype(int) + clipped
+        indx = np.floor(np.abs(x-self.x[0])/self.delta_x).astype(int) + clipped
+        indy = np.floor(np.abs(y-self.y[0])/self.delta_y).astype(int) + clipped
         buffer = self.buffer  # Adding buffer, to cover also future positions of elements
         indy = np.arange(np.max([0, indy.min()-buffer]),
                          np.min([indy.max()+buffer, self.numy]))


### PR DESCRIPTION
The part of the grid corresponding to the active particles is calculated using xmin and ymin, but this should be x[0] and y[0]. For coordinates in decreasing order the minimum is not the same as the first value and the wrong part of the grid would be loaded. The use of np.abs here avoids having to use a signed delta_x and delta_y, which could break code in other places.