### PR TITLE
All submodels of OceanDrift shall now have a required environment var…

### DIFF
--- a/examples/example_mixed_layer_depth.py
+++ b/examples/example_mixed_layer_depth.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+"""
+Mixing down to Mixed Layer Depth
+================================
+"""
+
+from datetime import datetime, timedelta
+from opendrift.models.oceandrift import OceanDrift
+from opendrift.readers.reader_constant import Reader as ConstantReader
+
+#%
+# Mixed Layer Depth of 20m West of 3 deg E, and 50m to the east
+r1 = ConstantReader({'ocean_mixed_layer_thickness': 20})
+r2 = ConstantReader({'ocean_mixed_layer_thickness': 50})
+r1.xmax = 3
+r2.xmin = 3
+
+#% 
+# First with Sundby1983 parameterization of diffusivity, based on wind and MLD
+o = OceanDrift(loglevel=50)
+o.seed_cone(lon=[2, 4], lat=[60, 60], time=datetime.now(), number=5000)
+o.add_reader([r1, r2])
+o.set_config('environment:constant:y_wind', 8)  # Some wind for mixing
+o.set_config('drift:vertical_mixing', True)
+o.set_config('vertical_mixing:diffusivitymodel', 'windspeed_Sundby1983')
+o.set_config('vertical_mixing:background_diffusivity', 0.001)
+o.run(duration=timedelta(hours=48))
+o.animation_profile()
+
+#%%
+# .. image:: /gallery/animations/example_mixed_layer_depth_0.gif
+
+#% 
+# Same, but with Large1994 parameterization of diffusivity
+o = OceanDrift(loglevel=50)
+o.seed_cone(lon=[2, 4], lat=[60, 60], time=datetime.now(), number=5000)
+o.add_reader([r1, r2])
+o.set_config('environment:constant:y_wind', 8)  # Some wind for mixing
+o.set_config('drift:vertical_mixing', True)
+o.set_config('vertical_mixing:diffusivitymodel', 'windspeed_Large1994')
+o.set_config('vertical_mixing:background_diffusivity', 0.001)
+o.run(duration=timedelta(hours=48))
+o.animation_profile()
+
+#%%
+# .. image:: /gallery/animations/example_mixed_layer_depth_1.gif
+
+#% 
+# Using Large1994, but with 0 diffusivity below MLD
+o = OceanDrift(loglevel=50)
+o.seed_cone(lon=[2, 4], lat=[60, 60], time=datetime.now(), number=5000)
+o.add_reader([r1, r2])
+o.set_config('environment:constant:y_wind', 8)  # Some wind for mixing
+o.set_config('drift:vertical_mixing', True)
+o.set_config('vertical_mixing:diffusivitymodel', 'windspeed_Large1994')
+o.set_config('vertical_mixing:background_diffusivity', 0)
+o.run(duration=timedelta(hours=48))
+o.animation_profile()
+
+#%%
+# .. image:: /gallery/animations/example_mixed_layer_depth_2.gif

--- a/opendrift/models/chemicaldrift.py
+++ b/opendrift/models/chemicaldrift.py
@@ -121,7 +121,7 @@ class ChemicalDrift(OceanDrift):
         'upward_sea_water_velocity': {'fallback': 0},
         'conc3': {'fallback': 1.e-3},
         'spm': {'fallback': 50},
-        'ocean_mixed_layer_thickness_defined_by_sigma_theta': {'fallback': 50},
+        'ocean_mixed_layer_thickness': {'fallback': 50},
 #        'mass_concentration_of_suspended_matter_in_sea_water': {'fallback': 0},
         }
 

--- a/opendrift/models/larvalfish.py
+++ b/opendrift/models/larvalfish.py
@@ -73,6 +73,7 @@ class LarvalFish(OceanDrift):
         'land_binary_mask': {'fallback': None},
         'sea_floor_depth_below_sea_level': {'fallback': 100},
         'ocean_vertical_diffusivity': {'fallback': 0.01, 'profiles': True},
+        'ocean_mixed_layer_thickness': {'fallback': 50},
         'sea_water_temperature': {'fallback': 10, 'profiles': True},
         'sea_water_salinity': {'fallback': 34, 'profiles': True}
     }

--- a/opendrift/models/oceandrift.py
+++ b/opendrift/models/oceandrift.py
@@ -80,6 +80,7 @@ class OceanDrift(OpenDriftSimulation):
         'surface_downward_y_stress': {'fallback': 0},
         'turbulent_kinetic_energy': {'fallback': 0},
         'turbulent_generic_length_scale': {'fallback': 0},
+        'ocean_mixed_layer_thickness': {'fallback': 50},
         'sea_floor_depth_below_sea_level': {'fallback': 10000},
         'land_binary_mask': {'fallback': None},
         }
@@ -239,7 +240,7 @@ class OceanDrift(OpenDriftSimulation):
     def get_diffusivity_profile(self, model):
         depths = np.abs(self.environment_profiles['z'])
         wind, depth = np.meshgrid(self.wind_speed(), depths)
-        MLD = 50  # TODO: obtain from readers/environment
+        MLD = self.environment.ocean_mixed_layer_thickness
         background_diffusivity = self.get_config('vertical_mixing:background_diffusivity')
 
         if model == 'windspeed_Large1994':
@@ -306,7 +307,8 @@ class OceanDrift(OpenDriftSimulation):
             else:
                 logger.debug('Using diffusivity from Large1994 since model diffusivities not available')
                 # Using higher vertical resolution when analytical
-                self.environment_profiles['z'] = -np.arange(0, 50)
+                self.environment_profiles['z'] = \
+                        -np.arange(0, self.environment.ocean_mixed_layer_thickness.max() + 2)
                 Kprofiles = self.get_diffusivity_profile('windspeed_Large1994')
         elif diffusivity_model == 'constant':
             logger.debug('Using constant diffusivity specified by fallback_values[''ocean_vertical_diffusivity''] = %s m2.s-1' % (self.fallback_values['ocean_vertical_diffusivity']))
@@ -317,7 +319,8 @@ class OceanDrift(OpenDriftSimulation):
             # Using higher vertical resolution when analytical
             if self.environment_profiles is None:
                 self.environment_profiles = {}
-            self.environment_profiles['z'] = -np.arange(0, 50)
+            self.environment_profiles['z'] = \
+                    -np.arange(0, self.environment.ocean_mixed_layer_thickness.max() + 2)
             # Note: although analytical functions, z is discretised
             Kprofiles = self.get_diffusivity_profile(diffusivity_model)
 

--- a/opendrift/models/openoil.py
+++ b/opendrift/models/openoil.py
@@ -171,6 +171,7 @@ class OpenOil(OceanDrift):
         'sea_water_salinity': {'fallback': 34, 'profiles': True},
         'sea_floor_depth_below_sea_level': {'fallback': 10000},
         'ocean_vertical_diffusivity': {'fallback': 0.02, 'important': False, 'profiles': True},
+        'ocean_mixed_layer_thickness': {'fallback': 50, 'important': False},
         'land_binary_mask': {'fallback': None}
     }
 

--- a/opendrift/models/pelagicegg.py
+++ b/opendrift/models/pelagicegg.py
@@ -66,6 +66,7 @@ class PelagicEggDrift(OceanDrift):
         'land_binary_mask': {'fallback': None},
         'sea_floor_depth_below_sea_level': {'fallback': 100},
         'ocean_vertical_diffusivity': {'fallback': 0.02, 'profiles': True},
+        'ocean_mixed_layer_thickness': {'fallback': 50},
         'sea_water_temperature': {'fallback': 10, 'profiles': True},
         'sea_water_salinity': {'fallback': 34, 'profiles': True},
         'surface_downward_x_stress': {'fallback': 0},

--- a/opendrift/models/physics_methods.py
+++ b/opendrift/models/physics_methods.py
@@ -76,7 +76,8 @@ def verticaldiffusivity_Sundby1983(windspeed, depth, mixedlayerdepth=50, backgro
     '''
 
     K = 76.1e-4 + 2.26e-4 * windspeed*windspeed * np.ones(np.atleast_1d(depth.shape))
-    K[depth>mixedlayerdepth] = background_diffusivity  # Cutoff below mixed layer
+    K[depth>mixedlayerdepth-1] = (K[depth>mixedlayerdepth-1]+background_diffusivity)/2  # Transition
+    K[depth>=mixedlayerdepth] = background_diffusivity  # Cutoff below mixed layer
     # valid = windspeed_squared < 13**2
     return K
 

--- a/opendrift/models/plastdrift.py
+++ b/opendrift/models/plastdrift.py
@@ -52,6 +52,7 @@ class PlastDrift(OceanDrift):
         'x_wind': {'fallback': 0},
         'y_wind': {'fallback': 0},
         'ocean_vertical_diffusivity': {'fallback': 0.02, 'profiles': True},
+        'ocean_mixed_layer_thickness': {'fallback': 50},
         'sea_floor_depth_below_sea_level': {'fallback': 10000},
         'land_binary_mask': {'fallback': None},
         }

--- a/opendrift/models/radionuclides.py
+++ b/opendrift/models/radionuclides.py
@@ -79,6 +79,7 @@ class RadionuclideDrift(OceanDrift):
         'land_binary_mask': {'fallback': None},
         'sea_floor_depth_below_sea_level': {'fallback': None},
         'ocean_vertical_diffusivity': {'fallback': 0.0001, 'profiles': True},
+        'ocean_mixed_layer_thickness': {'fallback': 50},
         'sea_water_temperature': {'fallback': 10, 'profiles': True},
         'sea_water_salinity': {'fallback': 34, 'profiles': True},
 #        'surface_downward_x_stress': {'fallback': 0},

--- a/opendrift/models/sedimentdrift.py
+++ b/opendrift/models/sedimentdrift.py
@@ -53,6 +53,7 @@ class SedimentDrift(OceanDrift):
         'sea_surface_wave_mean_period_from_variance_spectral_density_second_frequency_moment': {'fallback': 0},
         'land_binary_mask': {'fallback': None},
         'ocean_vertical_diffusivity': {'fallback': 0.02},
+        'ocean_mixed_layer_thickness': {'fallback': 50},
         'sea_floor_depth_below_sea_level': {'fallback': 0},
         }
 

--- a/opendrift/readers/basereader/__init__.py
+++ b/opendrift/readers/basereader/__init__.py
@@ -69,6 +69,7 @@ class BaseReader(Variables):
         'barotropic_sea_water_x_velocity': 'sea_ice_x_velocity',
         'barotropic_sea_water_y_velocity': 'sea_ice_y_velocity',
         'salinity_vertical_diffusion_coefficient' : 'ocean_vertical_diffusivity',
+        'ocean_mixed_layer_thickness_defined_by_sigma_theta': 'ocean_mixed_layer_thickness',
         'sea_floor_depth_below_sea_surface' : 'sea_floor_depth_below_sea_level',
         'sea_floor_depth_below_geoid' : 'sea_floor_depth_below_sea_level',
         'mass_concentration_of_suspended_matter_in_sea_water' : 'spm'

--- a/tests/models/test_physics.py
+++ b/tests/models/test_physics.py
@@ -138,7 +138,7 @@ class TestPhysics(unittest.TestCase):
         #o.plot_vertical_distribution()
         #o.animation_profile()
         # Check minimum depth
-        self.assertAlmostEqual(o.elements.z.min(), -49.3, 1)
+        self.assertAlmostEqual(o.elements.z.min(), -50.3, 1)
         #######################################################
 
     def test_vertical_mixing_plantoil_windonly(self):
@@ -156,7 +156,7 @@ class TestPhysics(unittest.TestCase):
         o.set_config('vertical_mixing:timestep', 4)
         o.run(duration=timedelta(hours=2), time_step_output=900, time_step=900)
         #o.plot_vertical_distribution()
-        self.assertAlmostEqual(o.elements.z.min(), -48.5, 1)
+        self.assertAlmostEqual(o.elements.z.min(), -49.5, 1)
         #######################################################
 
 
@@ -177,7 +177,7 @@ class TestPhysics(unittest.TestCase):
         o.run(duration=timedelta(hours=2),
               time_step_output=1800, time_step=1800)
         #o.plot_vertical_distribution()
-        self.assertAlmostEqual(o.elements.z.min(), -48.7, 1)
+        self.assertAlmostEqual(o.elements.z.min(), -49.8, 1)
         ########################################################
 
     def test_verticalmixing_schemes(self):
@@ -199,11 +199,11 @@ class TestPhysics(unittest.TestCase):
             o.run(duration=timedelta(hours=2), time_step=900)
 
             if scheme == 'environment':  # presently this is fallback
-                self.assertAlmostEqual(o.elements.z.min(), -48.8, 1)
+                self.assertAlmostEqual(o.elements.z.min(), -49.1, 1)
             elif scheme == 'windspeed_Large1994':
-                self.assertAlmostEqual(o.elements.z.min(), -48.8, 1)
+                self.assertAlmostEqual(o.elements.z.min(), -49.1, 1)
             elif scheme == 'windspeed_Sundby1983':
-                self.assertAlmostEqual(o.elements.z.min(), -77.2, 1)
+                self.assertAlmostEqual(o.elements.z.min(), -55.3, 1)
             elif scheme == 'constant':
                 self.assertAlmostEqual(o.elements.z.min(), -3.62, 1)
 

--- a/tests/models/test_run.py
+++ b/tests/models/test_run.py
@@ -599,7 +599,7 @@ class TestRun(unittest.TestCase):
         #o.plot_property('z')
         z, status = o.get_property('z')
         self.assertAlmostEqual(z[0,0], -147.3, 1)  # Seeded at seafloor depth
-        self.assertAlmostEqual(z[-1,0], -122.6, 1)  # After some rising
+        self.assertAlmostEqual(z[-1,0], -122.2, 1)  # After some rising
 
     def test_seed_above_seafloor(self):
         o = OpenOil(loglevel=30)
@@ -623,7 +623,7 @@ class TestRun(unittest.TestCase):
         #o.plot_property('z')
         z, status = o.get_property('z')
         self.assertAlmostEqual(z[0,0], -97.3, 1)  # Seeded at seafloor depth
-        self.assertAlmostEqual(z[-1,0], -72.0, 1)  # After some rising
+        self.assertAlmostEqual(z[-1,0], -71.7, 1)  # After some rising
 
     def test_seed_below_reader_coverage(self):
         o = OpenOil(loglevel=20)
@@ -643,7 +643,7 @@ class TestRun(unittest.TestCase):
         o.set_config('vertical_mixing:timestep', 1)  # s
         o.run(steps=3, time_step=300, time_step_output=300)
         z, status = o.get_property('z')
-        self.assertAlmostEqual(z[-1,0], -134.27, 1)  # After some rising
+        self.assertAlmostEqual(z[-1,0], -134.0, 1)  # After some rising
 
     def test_seed_below_seafloor(self):
         o = OpenOil(loglevel=20)
@@ -665,7 +665,7 @@ class TestRun(unittest.TestCase):
         o.run(steps=3, time_step=300, time_step_output=300)
         z, status = o.get_property('z')
         self.assertAlmostEqual(z[0,0], -147.3, 1)  # Seeded at seafloor depth
-        self.assertAlmostEqual(z[-1,0], -132.5, 1)  # After some rising
+        self.assertAlmostEqual(z[-1,0], -132.1, 1)  # After some rising
 
     def test_seed_below_seafloor_deactivating(self):
         o = OpenOil(loglevel=50)
@@ -691,7 +691,7 @@ class TestRun(unittest.TestCase):
         self.assertEqual(o.num_elements_active(), 1)
         self.assertEqual(o.num_elements_deactivated(), 1)
         self.assertAlmostEqual(z[0,1], -100, 1)  # Seeded at seafloor depth
-        self.assertAlmostEqual(z[-1,1], -81.4, 1)  # After some rising
+        self.assertAlmostEqual(z[-1,1], -81.3, 1)  # After some rising
 
     def test_lift_above_seafloor(self):
         # See an element at some depth, and progapate towards coast


### PR DESCRIPTION
…iable ocean_mixed_layer_thickness, to be used in Sundby and Large parameterisations of vertical diffusivity (based on wind). Added new example to illustrate the use.