### PR TITLE
vertical_mixing: reflect particles from seafloor only if they are not supposed to be deactivated

### DIFF
--- a/examples/example_oil_ice.py
+++ b/examples/example_oil_ice.py
@@ -18,7 +18,7 @@ o.add_readers_from_list(['https://thredds.met.no/thredds/dodsC/barents25km_agg']
 #%%
 # Imaginary oil spill in Hinlopen strait
 o.seed_elements(lon=19.1909, lat=79.5986, radius=50,
-                number=3000, time=datetime.utcnow() - timedelta(hours=12))
+                number=3000, time=datetime.utcnow() - timedelta(days=7))
 
 #%%
 # Adjusting some configuration

--- a/opendrift/models/basemodel.py
+++ b/opendrift/models/basemodel.py
@@ -826,6 +826,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
         elif i == 'deactivate':
             self.deactivate_elements(self.elements.z < -sea_floor_depth,
                                      reason='seafloor')
+            self.elements.z[below] = -sea_floor_depth[below]
         elif i == 'previous':  # Go back to previous position (in water)
             logger.warning('%s elements hit seafloor, '
                            'moving back ' % len(below))
@@ -2406,6 +2407,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
         # Deactivate elements, if they have not already been deactivated
         self.elements.status[indices & (self.elements.status ==0)] = \
             reason_number
+        self.elements.moving[indices] = 0
         logger.debug('%s elements scheduled for deactivation (%s)' %
                      (np.sum(indices), reason))
         logger.debug(

--- a/opendrift/models/oceandrift.py
+++ b/opendrift/models/oceandrift.py
@@ -469,7 +469,7 @@ class OceanDrift(OpenDriftSimulation):
                 self.elements.z[reflect] = -self.elements.z[reflect]
 
             # Reflect elements going below seafloor
-            bottom = np.where(self.elements.z < Zmin)
+            bottom = np.where(np.logical_and(self.elements.z < Zmin, self.elements.moving == 1))
             if len(bottom[0]) > 0:
                 logger.debug('%s elements penetrated seafloor, lifting up' % len(bottom[0]))
                 self.elements.z[bottom] = 2*Zmin[bottom] - self.elements.z[bottom]


### PR DESCRIPTION
Without this fix elements were being deactivated at the end of the mixing loop and "freezing" slightly above seafloor