### PR TITLE
Sorting OpenOil oiltypes alphabetically with GENERIC oils first. Firs…

### DIFF
--- a/opendrift/models/openoil/openoil.py
+++ b/opendrift/models/openoil/openoil.py
@@ -279,19 +279,6 @@ class OpenOil(OceanDrift):
         'dispersed': 'magenta'
     }
 
-    duplicate_oils = [
-        'ALVHEIM BLEND, STATOIL', 'DRAUGEN, STATOIL', 'EKOFISK BLEND 2000',
-        'EKOFISK BLEND, STATOIL', 'EKOFISK, CITGO', 'EKOFISK, EXXON',
-        'EKOFISK, PHILLIPS', 'EKOFISK, STATOIL', 'ELDFISK', 'ELDFISK B',
-        'GLITNE, STATOIL', 'GOLIAT BLEND, STATOIL', 'GRANE BLEND, STATOIL',
-        'GUDRUN BLEND, STATOIL', 'GULLFAKS A, STATOIL', 'GULLFAKS C, STATOIL',
-        'GULLFAKS, SHELL OIL', 'GULLFAKS SOR', 'GULLFAKS, STATOIL',
-        'HEIDRUN, STATOIL', 'NJORD, STATOIL', 'NORNE, STATOIL',
-        'OSEBERG BLEND, STATOIL', 'OSEBERG EXXON', 'OSEBERG, PHILLIPS',
-        'OSEBERG, SHELL OIL', 'SLEIPNER CONDENSATE, STATOIL',
-        'STATFJORD BLEND, STATOIL', 'VARG, STATOIL'
-    ]
-
     # Workaround as ADIOS oil library uses
     # max water fraction of 0.9 for all crude oils
     max_water_fraction = {
@@ -308,6 +295,11 @@ class OpenOil(OceanDrift):
 
             # Update config with oiltypes
             self.oiltypes.extend(adios.oil_name_alias.keys())
+
+            # Sort alphabetically, but put GENERIC oils first
+            generic_oiltypes = [o for o in self.oiltypes if o[0:7] == 'GENERIC']
+            other_oiltypes = [o for o in self.oiltypes if o[0:7] != 'GENERIC']
+            self.oiltypes = sorted([o for o in generic_oiltypes]) + sorted([o for o in other_oiltypes])
         else:
             raise ValueError('Weathering model unknown: ' + weathering_model)
 
@@ -408,7 +400,7 @@ class OpenOil(OceanDrift):
                 'enum':
                 self.oiltypes,
                 'default':
-                'AASGARD A 2003',
+                self.oiltypes[0],
                 'level':
                 self.CONFIG_LEVEL_ESSENTIAL,
                 'description':

--- a/tests/models/openoil/test_openoil.py
+++ b/tests/models/openoil/test_openoil.py
@@ -80,7 +80,7 @@ def test_default_oil_type():
     o = OpenOil(loglevel=50)
     print('Default oil_type', o.get_config('seed:oil_type'))
 
-    assert o.get_config('seed:oil_type') == 'AASGARD A 2003'
+    assert o.get_config('seed:oil_type') == 'GENERIC BUNKER C'
 
 def test_set_oil_type():
     o = OpenOil(loglevel=50)

--- a/tests/models/test_physics.py
+++ b/tests/models/test_physics.py
@@ -131,7 +131,7 @@ class TestPhysics(unittest.TestCase):
         o.set_config('environment:fallback:x_sea_water_velocity', 0)
         o.set_config('environment:fallback:y_sea_water_velocity', 0)
         o.seed_elements(4, 60, number=1000, diameter=0.00002,  # r = 10 micron
-                        density=865, time=datetime.now())
+                        density=865, time=datetime.now(), oil_type='AASGARD A 2003')
         o.set_config('vertical_mixing:timestep', 4)
         o.run(duration=timedelta(hours=2), time_step_output=900, time_step=900)
         #o.plot_property('z')
@@ -151,7 +151,7 @@ class TestPhysics(unittest.TestCase):
         o.set_config('environment:fallback:x_sea_water_velocity', 0)
         o.set_config('environment:fallback:y_sea_water_velocity', 0)
         o.seed_elements(4, 60, number=1000, diameter=0.00002,  # r = 10 micron
-                        density=865, time=datetime.now())
+                        density=865, time=datetime.now(), oil_type='AASGARD A 2003')
 
         o.set_config('vertical_mixing:timestep', 4)
         o.run(duration=timedelta(hours=2), time_step_output=900, time_step=900)
@@ -171,7 +171,7 @@ class TestPhysics(unittest.TestCase):
         o.set_config('environment:fallback:x_sea_water_velocity', 0)
         o.set_config('environment:fallback:y_sea_water_velocity', 0)
         o.seed_elements(4, 60, number=1000, diameter=0.00002,  # r = 10 micron
-                        density=865, time=datetime.now())
+                        density=865, time=datetime.now(), oil_type='AASGARD A 2003')
 
         o.set_config('vertical_mixing:timestep', 4)
         o.run(duration=timedelta(hours=2),
@@ -192,7 +192,7 @@ class TestPhysics(unittest.TestCase):
             o.set_config('environment:fallback:y_sea_water_velocity', 0)
             o.set_config('environment:fallback:ocean_vertical_diffusivity', 0)
             o.seed_elements(4, 60, number=1000, diameter=0.00002,  # r = 10 micron
-                            density=865, time=datetime.now())
+                            density=865, time=datetime.now(), oil_type='AASGARD A 2003')
 
             #o.set_config('vertical_mixing:timestep', 4)
             o.set_config('vertical_mixing:diffusivitymodel', scheme)

--- a/tests/models/test_run.py
+++ b/tests/models/test_run.py
@@ -615,7 +615,7 @@ class TestRun(unittest.TestCase):
         o.set_config('seed:droplet_diameter_max_subsea', 0.0010)  # s
         # Seed elements 50 meters above seafloor:
         o.seed_elements(lon, lat, z='seafloor+50', time=reader_norkyst.start_time,
-                        density=1000)
+                        density=1000, oil_type='AASGARD A 2003')
         o.set_config('drift:vertical_mixing', True)
 
         o.set_config('vertical_mixing:timestep', 1)  # s
@@ -636,7 +636,7 @@ class TestRun(unittest.TestCase):
         o.set_config('seed:droplet_diameter_min_subsea', 0.0005)
         o.set_config('seed:droplet_diameter_max_subsea', 0.005)
         o.seed_elements(lon, lat, z=-350, time=reader_norkyst.start_time,
-                        density=1000)
+                        density=1000, oil_type='AASGARD A 2003')
         #o.set_config('vertical_mixing:TSprofiles', True)
         o.set_config('drift:vertical_mixing', True)
 
@@ -680,7 +680,7 @@ class TestRun(unittest.TestCase):
         o.set_config('seed:droplet_diameter_min_subsea', 0.0005)
         o.set_config('seed:droplet_diameter_max_subsea', 0.001)
         o.seed_elements(lon, lat, z=[-5000, -100], time=reader_norkyst.start_time,
-                        density=1000, number=2)
+                        density=1000, number=2, oil_type='AASGARD A 2003')
         o.set_config('general:seafloor_action', 'deactivate')  # This time we deactivate
         o.set_config('drift:vertical_mixing', True)
 


### PR DESCRIPTION
…t oil in list (GENERIC BUNKER C) is now default. Removing list of duplicate oils, which is deprecated.