### PR TITLE
Blit is now an input parameter to animation, defaulting to False, as …

### DIFF
--- a/examples/example_oil_ice.py
+++ b/examples/example_oil_ice.py
@@ -25,6 +25,7 @@ o.seed_elements(lon=19.1909, lat=79.5986, radius=50,
 o.set_config('processes:dispersion',  False)
 o.set_config('processes:evaporation',  False)
 o.set_config('processes:emulsification',  False)
+o.set_config('drift:horizontal_diffusivity', 10)
 o.set_config('drift:truncate_ocean_model_below_m', 3)
 
 #%%

--- a/opendrift/models/basemodel.py
+++ b/opendrift/models/basemodel.py
@@ -3249,6 +3249,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
                                                      width=lonmx - lonmn,
                                                      height=latmx - latmn,
                                                      transform=ccrs.Geodetic(),
+                                                     zorder=10,
                                                      **bx)
                 ax.add_patch(patch)
 
@@ -3346,6 +3347,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
                   fps=8,
                   lscale=None,
                   fast=False,
+                  blit=False,
                   **kwargs):
         """Animate last run."""
 
@@ -3541,6 +3543,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
                                map_y,
                                scalar[:-1, :-1],
                                alpha=bgalpha,
+                               zorder=1,
                                antialiased=True,
                                linewidth=0.0,
                                rasterized=True,
@@ -3554,6 +3557,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
                                     u_component[::skip, ::skip],
                                     v_component[::skip, ::skip],
                                     scale=scale,
+                                    zorder=1,
                                     transform=gcrs)
 
         if lcs is not None:
@@ -3747,7 +3751,8 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
         if compare is not None:
             frames = min(x.shape[0], cd['x_other'].shape[1])
 
-        blit = sys.platform != 'darwin'  # blitting does not work on mac os
+        # blit is now provided to animation()
+        #blit = sys.platform != 'darwin'  # blitting does not work on mac os
 
         self.__save_or_plot_animation__(plt.gcf(),
                                         plot_timestep,
@@ -4340,6 +4345,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
                                              map_y,
                                              scalar,
                                              alpha=bgalpha,
+                                             zorder=1,
                                              vmin=vmin,
                                              vmax=vmax,
                                              cmap=cmap,
@@ -4385,7 +4391,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
                       u_component[::skip, ::skip],
                       v_component[::skip, ::skip],
                       scale=scale,
-                      transform=gcrs)
+                      transform=gcrs, zorder=1)
 
         if lcs is not None:
             map_x_lcs, map_y_lcs = (lcs['lon'], lcs['lat'])

--- a/opendrift/models/leeway.py
+++ b/opendrift/models/leeway.py
@@ -438,7 +438,7 @@ class Leeway(OpenDriftSimulation):
 
     def _substance_name(self):
         # TODO: find a better algorithm to return name of object category
-        if hasattr(self, 'history'):
+        if self.history is not None:
             object_type = self.history['object_type'][0,0]
             if not np.isfinite(object_type):  # For backward simulations
                 object_type = self.history['object_type'][-1,0]

--- a/opendrift/readers/reader_global_landmask.py
+++ b/opendrift/readers/reader_global_landmask.py
@@ -88,6 +88,7 @@ def plot_land(ax, lonmin, latmin, lonmax, latmax, fast, ocean_color = 'white', l
         from matplotlib import colors
         cmap = colors.ListedColormap([ocean_color, land_color])
         ax.imshow(img, origin = 'lower', extent=[lonmin, lonmax, latmin, latmax],
+                  zorder=0,
                     transform=ccrs.PlateCarree(), cmap=cmap)
 
     def show_landmask_old(landmask):
@@ -111,6 +112,7 @@ def plot_land(ax, lonmin, latmin, lonmax, latmax, fast, ocean_color = 'white', l
         from matplotlib import colors
         cmap = colors.ListedColormap([ocean_color, land_color])
         ax.imshow(img, origin = 'lower', extent=[lonmin, lonmax, latmin, latmax],
+                  zorder=0,
                     transform=ccrs.PlateCarree(), cmap=cmap)
 
     extent = [lonmin, latmin, lonmax, latmax]
@@ -131,6 +133,7 @@ def plot_land(ax, lonmin, latmin, lonmax, latmax, fast, ocean_color = 'white', l
 
             ax.add_geometries(polys,
                     ccrs.PlateCarree(),
+                    zorder=2,
                     facecolor=land_color,
                     edgecolor='black')
         else:


### PR DESCRIPTION
…blitting destroys zorder (background field is always overlaid landmask). Now bitmap/roaring landmask has zorder=0, bacground has zorder=1, and GSHHG has zorder=2, so that background is below GSHHS but above bitmap