### PR TITLE
Added option to chose ensemble member in reader_netCDF_CF_generic.py

### DIFF
--- a/opendrift/readers/reader_netCDF_CF_generic.py
+++ b/opendrift/readers/reader_netCDF_CF_generic.py
@@ -114,8 +114,7 @@ class Reader(StructuredReader, BaseReader):
 
     """
 
-    def __init__(self, filename=None, name=None, proj4=None, standard_name_mapping={}):
-
+    def __init__(self, filename=None, name=None, proj4=None, standard_name_mapping={}, ensemble_member=None):
         if filename is None:
             raise ValueError('Need filename as argument to constructor')
 
@@ -132,8 +131,11 @@ class Reader(StructuredReader, BaseReader):
                 logger.info('Opening files with MFDataset')
                 self.Dataset = xr.open_mfdataset(filename, data_vars='minimal', coords='minimal',
                                                  chunks={'time': 1}, decode_times=False)
+            elif ensemble_member is not None:
+                self.Dataset = xr.open_dataset(filename, decode_times=False).isel(ensemble_member=ensemble_member)
             else:
                 self.Dataset = xr.open_dataset(filename, decode_times=False)
+
         except Exception as e:
             raise ValueError(e)
 
@@ -231,10 +233,11 @@ class Reader(StructuredReader, BaseReader):
                 else:
                     self.time_step = None
             if standard_name == 'realization':
-                var_data = var.values
-                self.realizations = var_data
-                logger.debug('%i ensemble members available'
-                              % len(self.realizations))
+                if ensemble_member == None:
+                    var_data = var.values
+                    self.realizations = var_data
+                    logger.debug('%i ensemble members available'
+                                % len(self.realizations))
 
         # Temporary workaround for Barents EPS model
         if self.realizations is None and 'ensemble_member' in self.Dataset.dims:

--- a/opendrift/readers/reader_netCDF_CF_generic.py
+++ b/opendrift/readers/reader_netCDF_CF_generic.py
@@ -135,7 +135,6 @@ class Reader(StructuredReader, BaseReader):
                 self.Dataset = xr.open_dataset(filename, decode_times=False).isel(ensemble_member=ensemble_member)
             else:
                 self.Dataset = xr.open_dataset(filename, decode_times=False)
-
         except Exception as e:
             raise ValueError(e)
 


### PR DESCRIPTION
Added functionality to the reader to chose which ensemble member should be used when working with ensemble data. 
Added an argument in the function call called "ensemble_member", which defaults to None. This argument takes in an integer. 
Added a if statement when initially reading in the data, which checks if the "ensemble_member" argument has been used, and if it has, then it will read in data from that specific ensemble member using xarrays .isel() option. 
