### PR TITLE
Speeding up allocation of self.history in import_file

### DIFF
--- a/opendrift/export/io_netcdf.py
+++ b/opendrift/export/io_netcdf.py
@@ -325,7 +325,8 @@ def import_file(self, filename, times=None, elements=None, load_history=True):
     if load_history is True:
         self.history = np.ma.array(
             np.zeros([num_elements, self.steps_output]),
-            dtype=history_dtype, mask=[True])
+            dtype=history_dtype)
+        self.history = =np.ma.masked
         for var in infile.variables:
             if var in ['time', 'trajectory']:
                 continue

--- a/opendrift/export/io_netcdf.py
+++ b/opendrift/export/io_netcdf.py
@@ -326,7 +326,7 @@ def import_file(self, filename, times=None, elements=None, load_history=True):
         self.history = np.ma.array(
             np.zeros([num_elements, self.steps_output]),
             dtype=history_dtype)
-        self.history = =np.ma.masked
+        self.history = np.ma.masked
         for var in infile.variables:
             if var in ['time', 'trajectory']:
                 continue

--- a/opendrift/export/io_netcdf.py
+++ b/opendrift/export/io_netcdf.py
@@ -319,9 +319,6 @@ def import_file(self, filename, times=None, elements=None, load_history=True):
         elements = firstlast[0][0]
         logger.warning('A subset is requested, and number of active elements is %d'
                        % num_elements)
-    self.history = np.ma.array(
-        np.zeros([num_elements, self.steps_output]),
-        dtype=history_dtype, mask=[True])
     if load_history is True:
         self.history = np.ma.array(
             np.zeros([num_elements, self.steps_output]),

--- a/opendrift/export/io_netcdf.py
+++ b/opendrift/export/io_netcdf.py
@@ -326,7 +326,7 @@ def import_file(self, filename, times=None, elements=None, load_history=True):
         self.history = np.ma.array(
             np.zeros([num_elements, self.steps_output]),
             dtype=history_dtype)
-        self.history = np.ma.masked
+        self.history[:] = np.ma.masked
         for var in infile.variables:
             if var in ['time', 'trajectory']:
                 continue


### PR DESCRIPTION
for some reason numpy.ma.array allocation is extremely slow when mask=True is passed