### PR TITLE
Fix initial particle positions when using radius

### DIFF
--- a/opendrift/models/basemodel.py
+++ b/opendrift/models/basemodel.py
@@ -1845,6 +1845,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable):
                 y = np.random.randn(np.sum(number)) * radius
                 az = np.degrees(np.arctan2(x, y))
                 dist = np.sqrt(x * x + y * y)
+                dist = dist * (radius/np.max(dist)) # set dist to range [0,radius]
             elif radius_type == 'uniform':
                 az = np.random.randn(np.sum(number)) * 360
                 dist = np.sqrt(np.random.uniform(0, 1,


### PR DESCRIPTION
adding line below 

dist = dist * (radius/np.max(dist)) # set dist to range [0,radius]

np.random.randn(np.sum(number)) * radius return random numbers with mean=0 and variance=1 but they are not in range [-1,1].