### PR TITLE
correction factor to make diffusivity profile approach background diffusivity at depth==MLD

### DIFF
--- a/opendrift/models/physics_methods.py
+++ b/opendrift/models/physics_methods.py
@@ -270,7 +270,7 @@ def verticaldiffusivity_Large1994(windspeed, depth, mixedlayerdepth=50, backgrou
     cd = 1.25e-3  # Kara et al. 2007
     windstress = windspeed*windspeed * cd * rhoa
 
-    K = MLD * stabilityfunction(depth/MLD) * 0.4 * G(depth/MLD) * windstress
+    K = MLD * stabilityfunction(depth/MLD) * 0.4 * G(depth/MLD) * windstress + (depth/MLD)*background_diffusivity
     K[depth>=MLD] = background_diffusivity
 
     return K

--- a/tests/models/test_physics.py
+++ b/tests/models/test_physics.py
@@ -157,7 +157,7 @@ class TestPhysics(unittest.TestCase):
         o.set_config('vertical_mixing:timestep', 4)
         o.run(duration=timedelta(hours=2), time_step_output=900, time_step=900)
         #o.plot_vertical_distribution()
-        self.assertAlmostEqual(o.elements.z.min(), -49.5, 1)
+        self.assertAlmostEqual(o.elements.z.min(), -49.3, 1)
         #######################################################
 
 

--- a/tests/models/test_run.py
+++ b/tests/models/test_run.py
@@ -630,7 +630,7 @@ class TestRun(unittest.TestCase):
         #o.plot_property('z')
         z, status = o.get_property('z')
         self.assertAlmostEqual(z[0,0], -97.3, 1)  # Seeded at seafloor depth
-        self.assertAlmostEqual(z[-1,0], -38.4, 1)  # After some rising
+        self.assertAlmostEqual(z[-1,0], -38.3, 1)  # After some rising
 
     def test_seed_below_reader_coverage(self):
         o = OpenOil(loglevel=20)

--- a/tests/models/test_stranding.py
+++ b/tests/models/test_stranding.py
@@ -57,7 +57,7 @@ class TestStranding(unittest.TestCase):
 
         # Check calculated trajectory lengths and speeds
         total_length, distances, speeds = o.get_trajectory_lengths()
-        self.assertAlmostEqual(total_length.max(), 14978.3, 1)
+        self.assertAlmostEqual(total_length.max(), 14978.4, 1)
         self.assertAlmostEqual(total_length.min(), 1225.2, 1)
         self.assertAlmostEqual(speeds.max(), 0.127, 1)
         self.assertAlmostEqual(distances.max(), 2859.0, 1)


### PR DESCRIPTION
and avoid discontinuity at depth==MLD
should be ready to merge if you guys agree

this is just a small linearly increasing correction factor, which is 0 at depth=0, and gradually increasing to background_diffusivity when depth==MLD.

This discontinuity caused problems in some cases