### PR TITLE
Added east/north Stokes components to mapping list. Fixed bug in rota…

### DIFF
--- a/opendrift/readers/basereader/__init__.py
+++ b/opendrift/readers/basereader/__init__.py
@@ -89,7 +89,9 @@ class BaseReader(Variables, Combine, Filter):
                                  'northward_eulerian_current_velocity', 'surface_geostrophic_northward_sea_water_velocity',
                                  'surface_geostrophic_northward_sea_water_velocity_assuming_sea_level_for_geoid',
                                  'surface_northward_geostrophic_sea_water_velocity_assuming_sea_level_for_geoid'],
-        'x_wind': 'eastward_wind', 'y_wind': 'northward_wind'}
+        'x_wind': 'eastward_wind', 'y_wind': 'northward_wind',
+        'sea_surface_wave_stokes_drift_x_velocity': 'eastward_surface_stokes_drift',
+        'sea_surface_wave_stokes_drift_y_velocity': 'northward_surface_stokes_drift'}
 
     def __init__(self):
         """Common constructor for all readers"""
@@ -170,7 +172,7 @@ class BaseReader(Variables, Combine, Filter):
             self.activate_environment_mapping(m)
 
     def y_is_north(self):
-        if self.proj.crs.is_geographic or '+proj=merc' in self.proj.srs:
+        if (self.proj.crs.is_geographic and 'ob_tran' not in self.proj4) or '+proj=merc' in self.proj.srs:
             return True
         else:
             return False
@@ -181,13 +183,14 @@ class BaseReader(Variables, Combine, Filter):
         pass  # to be overriden by specific readers
 
     def rotate_variable_dict(self, variables, proj_from='+proj=latlong', proj_to=None):
+        vx, vy = np.meshgrid(variables['x'], variables['y'])
         for vectorpair in vector_pairs_xy:
             if vectorpair[0] in self.rotate_mapping and vectorpair[0] in variables.keys():
                 if proj_to is None:
                     proj_to = self.proj
                 logger.debug('Rotating vector from east/north to xy orientation: ' + str(vectorpair))
                 variables[vectorpair[0]], variables[vectorpair[1]] = self.rotate_vectors(
-                    variables['x'], variables['y'],
+                    vx, vy,
                     variables[vectorpair[0]], variables[vectorpair[1]],
                     proj_from, proj_to)
 

--- a/opendrift/readers/basereader/variables.py
+++ b/opendrift/readers/basereader/variables.py
@@ -722,7 +722,7 @@ class Variables(ReaderDomain):
 
         # Rotating vectors fields
         if rotate_to_proj is not None:
-            if self.proj.crs.is_geographic:
+            if self.proj.crs.is_geographic and 'ob_tran' not in self.proj4:
                 logger.debug('Reader projection is latlon - '
                              'rotation of vectors is not needed.')
             else:

--- a/opendrift/readers/reader_netCDF_CF_generic.py
+++ b/opendrift/readers/reader_netCDF_CF_generic.py
@@ -144,7 +144,7 @@ class Reader(StructuredReader, BaseReader):
                     long_name.lower() == 'latitude' or \
                     var_name.lower() in ['latitude', 'lat']:
                 lat_var_name = var_name
-            if (axis == 'X' or standard_name == 'projection_x_coordinate') \
+            if (axis == 'X' or standard_name == 'projection_x_coordinate' or standard_name == 'grid_longitude') \
                     and var.ndim == 1:
                 self.xname = var_name
                 # Fix for units; should ideally use udunits package
@@ -154,7 +154,7 @@ class Reader(StructuredReader, BaseReader):
                     self.unitfactor = 100000
                 var_data = var.values
                 x = var_data*self.unitfactor
-            if (axis == 'Y' or standard_name == 'projection_y_coordinate') \
+            if (axis == 'Y' or standard_name == 'projection_y_coordinate' or standard_name == 'grid_latitude') \
                     and var.ndim == 1:
                 self.yname = var_name
                 # Fix for units; should ideally use udunits package


### PR DESCRIPTION
…te_variable_dict. Detecting now standard_name grid_latitude/longitude as x/y-coordinates, and now also rotating vectors when CRS is ob_tran.