### PR TITLE
Set same default ocean floor depth in SedimentDrift as in OceanDrift

### DIFF
--- a/opendrift/models/sedimentdrift.py
+++ b/opendrift/models/sedimentdrift.py
@@ -54,7 +54,7 @@ class SedimentDrift(OceanDrift):
         'land_binary_mask': {'fallback': None},
         'ocean_vertical_diffusivity': {'fallback': 0.02},
         'ocean_mixed_layer_thickness': {'fallback': 50},
-        'sea_floor_depth_below_sea_level': {'fallback': 0},
+        'sea_floor_depth_below_sea_level': {'fallback': 10000},
         }
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
I just spent way too much time figuring out why my particles always ended up at -0.01 depth. Turns out the default depth of the SedimentDrift module is 0, which is not very helpful.