### PR TITLE
Replace a test expression to prevent a logical short circuit

### DIFF
--- a/opendrift/readers/interpolation/structured.py
+++ b/opendrift/readers/interpolation/structured.py
@@ -88,7 +88,7 @@ class ReaderBlock():
         self._initialize_interpolator(x, y, z)
 
         env_dict = {}
-        if profiles is not []:
+        if not profiles:
             profiles_dict = {'z': self.z}
         for varname, data in self.data_dict.items():
             nearest = False


### PR DESCRIPTION
In file: structured.py, method: `interpolate`, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. 

The following binary operation

     profiles is not []

compares a newly created object with identity operator which will always evaluate to True.

I suggested that the logical operation should be reviewed for correctness. 

Sponsorship and Support:

This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.