### PR TITLE
Bug fixed

### DIFF
--- a/examples/example_biodegradation.py
+++ b/examples/example_biodegradation.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+"""
+Biodegradation of oil
+======================
+"""
+
+import numpy as np
+from datetime import datetime, timedelta
+from opendrift.readers import reader_netCDF_CF_generic
+from opendrift.models.openoil import OpenOil
+
+o = OpenOil(loglevel=0)  # Set loglevel to 0 for debug information
+time = datetime.now()
+
+# No motion is needed for this test
+o.set_config('environment:constant', {k: 0 for k in
+             ['x_wind', 'y_wind', 'x_sea_water_velocity', 'y_sea_water_velocity']})
+o.set_config('drift', {'current_uncertainty': 0, 'wind_uncertainty': 0})
+
+#%%
+# Seeding some particles
+o.set_config('drift:vertical_mixing', False)  # Keeping oil at fixed depths
+o.set_config('processes:biodegradation', True)
+o.set_config('biodegradation:method', 'decay_rate')
+
+#%%
+# Fast decay for droplets, and slow decay for slick 
+decay = {'biodegradation_decay_rate_slick': np.log(2)/timedelta(days=100).total_seconds(),
+         'biodegradation_decay_rate_droplet': np.log(2)/timedelta(days=3).total_seconds(),
+         'oil_type': 'GENERIC MEDIUM CRUDE', 'm3_per_hour': .5}
+
+#%%
+# Seed 5000 oil elements at surface, and 5000 elements at 100m depth
+o.seed_elements(lon=4, lat=60.0, z=0, number=5000, time=datetime.now(), **decay)
+o.seed_elements(lon=4, lat=60.0, z=-100, number=5000, time=datetime.now(), **decay)
+
+#%%
+# Running model
+o.run(duration=timedelta(hours=24), time_step=900) 
+
+#%%
+# Print and plot results
+o.plot_oil_budget(show_watercontent_and_viscosity=False, show_wind_and_current=False)

--- a/examples/example_macondo.py
+++ b/examples/example_macondo.py
@@ -48,6 +48,7 @@ if reader_globcurrent is not None:
     o.plot(fast=True)
     o.plot_oil_budget()
     o.animation(fast=True)
+    o.animation(fast=True, frames = range(0, 120, 4), fps = 1)
 
 #%%
 # .. image:: /gallery/animations/example_macondo_0.gif

--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -2628,6 +2628,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         lscale=None,
         fast=False,
         blit=False,
+        frames=None,
         **kwargs,
     ):
         """Animate last run."""
@@ -3155,7 +3156,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             )
             cb.set_label(clabel)
 
-        frames = x.shape[0]
+        frames = x.shape[0] if frames is None else frames
 
         if compare is not None:
             frames = min(x.shape[0], cd["x_other"].shape[1])
@@ -4836,7 +4837,8 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         if writer is not None:
             with writer.saving(fig, filename, None):
-                for i in range(frames):
+                print(frames)
+                for i in frames if isinstance(frames, (list, range)) else range(frames):
                     plot_timestep(i)
                     writer.grab_frame()
 

--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -2628,6 +2628,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         lscale=None,
         fast=False,
         blit=False,
+                  frames=None,
         frames=None,
         **kwargs,
     ):
@@ -3156,6 +3157,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             )
             cb.set_label(clabel)
 
+        frames = x.shape[0] if frames is None else frames
         frames = x.shape[0] if frames is None else frames
 
         if compare is not None:
@@ -4837,6 +4839,8 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         if writer is not None:
             with writer.saving(fig, filename, None):
+                print(frames)
+                for i in frames if isinstance(frames, (list, range)) else range(frames):
                 print(frames)
                 for i in frames if isinstance(frames, (list, range)) else range(frames):
                     plot_timestep(i)

--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -38,9 +38,9 @@ import scipy
 import pyproj
 import matplotlib
 
-matplotlib.rcParams['legend.numpoints'] = 1
-matplotlib.rcParams['legend.scatterpoints'] = 1
-matplotlib.rcParams['figure.autolayout'] = True
+matplotlib.rcParams["legend.numpoints"] = 1
+matplotlib.rcParams["legend.scatterpoints"] = 1
+matplotlib.rcParams["figure.autolayout"] = True
 import matplotlib.pyplot as plt
 from matplotlib import animation
 from matplotlib.patches import Polygon
@@ -56,7 +56,7 @@ from opendrift.errors import WrongMode
 from opendrift.models.physics_methods import PhysicsMethods
 from opendrift.config import Configurable, CONFIG_LEVEL_BASIC, CONFIG_LEVEL_ADVANCED
 
-Mode = Enum('Mode', ['Config', 'Ready', 'Run', 'Result'])
+Mode = Enum("Mode", ["Config", "Ready", "Run", "Result"])
 
 
 def require_mode(mode: Union[Mode, List[Mode]], post_next_mode=False, error=None):
@@ -167,23 +167,39 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
     mode = Mode.Config
 
-    status_categories = ['active']  # Particles are active by default
+    status_categories = ["active"]  # Particles are active by default
 
     # Default plotting colors of trajectory endpoints
     status_colors_default = {
-        'initial': 'green',
-        'active': 'blue',
-        'missing_data': 'gray'
+        "initial": "green",
+        "active": "blue",
+        "missing_data": "gray",
     }
 
     plot_comparison_colors = [
-        'k', 'r', 'g', 'b', 'm', 'c', 'y', 'crimson', 'indigo', 'lightcoral',
-        'grey', 'sandybrown', 'palegreen', 'gold', 'yellowgreen', 'lime',
-        'steelblue', 'navy', 'darkviolet'
+        "k",
+        "r",
+        "g",
+        "b",
+        "m",
+        "c",
+        "y",
+        "crimson",
+        "indigo",
+        "lightcoral",
+        "grey",
+        "sandybrown",
+        "palegreen",
+        "gold",
+        "yellowgreen",
+        "lime",
+        "steelblue",
+        "navy",
+        "darkviolet",
     ]
     plot_comparison_colors = plot_comparison_colors + plot_comparison_colors
 
-    proj_latlon = pyproj.Proj('+proj=latlong')
+    proj_latlon = pyproj.Proj("+proj=latlong")
     """
     The environment holds all the readers and the forcing data for the simulation.
     """
@@ -193,12 +209,14 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
     def SRS(cls):
         return cls.proj_latlon
 
-    def __init__(self,
-                 seed=0,
-                 iomodule='netcdf',
-                 loglevel=logging.DEBUG,
-                 logtime='%H:%M:%S',
-                 logfile=None):
+    def __init__(
+        self,
+        seed=0,
+        iomodule="netcdf",
+        loglevel=logging.DEBUG,
+        logtime="%H:%M:%S",
+        logfile=None,
+    ):
         """Initialise OpenDriftSimulation
 
         Args:
@@ -226,21 +244,23 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         self.origin_marker = None  # Dictionary to store named seeding locations
 
-        self.minvals = {
-        }  # Dicionaries to store minimum and maximum values of variables
+        self.minvals = (
+            {}
+        )  # Dicionaries to store minimum and maximum values of variables
         self.maxvals = {}
 
         # List to store GeoJSON dicts of seeding commands
         self.seed_geojson = []
 
-        self.env = Environment(self.required_variables,
-                               self.required_profiles_z_range, self._config)
+        self.env = Environment(
+            self.required_variables, self.required_profiles_z_range, self._config
+        )
 
         # Make copies of dictionaries so that they are private to each instance
-        self.status_categories = ['active']  # Particles are active by default
+        self.status_categories = ["active"]  # Particles are active by default
         self.status_colors_default = self.status_colors_default.copy()
 
-        if hasattr(self, 'status_colors'):
+        if hasattr(self, "status_colors"):
             # Append model specific colors to (and override) default colors
             self.status_colors_default.update(self.status_colors)
             self.status_colors = self.status_colors_default
@@ -257,11 +277,11 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         self.elements_deactivated = self.ElementType()  # Empty array
         self.elements = self.ElementType()  # Empty array
 
-        if loglevel != 'custom':
-            format = '%(levelname)-7s %(name)s:%(lineno)d: %(message)s'
+        if loglevel != "custom":
+            format = "%(levelname)-7s %(name)s:%(lineno)d: %(message)s"
             datefmt = None
             if logtime is not False:
-                format = '%(asctime)s ' + format
+                format = "%(asctime)s " + format
                 if logtime is not True:
                     datefmt = logtime
             formatter = logging.Formatter(format, datefmt=datefmt)
@@ -270,11 +290,11 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 loglevel = 10
 
             od_loggers = [
-                logging.getLogger('opendrift'),
+                logging.getLogger("opendrift"),
             ]
 
             if logfile is not None:
-                handler = logging.FileHandler(logfile, mode='w')
+                handler = logging.FileHandler(logfile, mode="w")
                 handler.setFormatter(formatter)
                 for l in od_loggers:
                     l.setLevel(loglevel)
@@ -282,226 +302,195 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                     l.addHandler(handler)
             else:
                 import coloredlogs
+
                 fields = coloredlogs.DEFAULT_FIELD_STYLES
-                fields['levelname']['color'] = 'magenta'
+                fields["levelname"]["color"] = "magenta"
 
                 # coloredlogs does not create duplicate handlers
                 for l in od_loggers:
-                    coloredlogs.install(level=loglevel,
-                                        logger=l,
-                                        fmt=format,
-                                        datefmt=datefmt,
-                                        field_styles=fields)
+                    coloredlogs.install(
+                        level=loglevel,
+                        logger=l,
+                        fmt=format,
+                        datefmt=datefmt,
+                        field_styles=fields,
+                    )
 
         # Prepare outfile
         try:
             io_module = __import__(
-                'opendrift.export.io_' + iomodule,
-                fromlist=['init', 'write_buffer', 'close', 'import_file'])
+                "opendrift.export.io_" + iomodule,
+                fromlist=["init", "write_buffer", "close", "import_file"],
+            )
         except ImportError:
-            logger.info('Could not import iomodule ' + iomodule)
+            logger.info("Could not import iomodule " + iomodule)
         self.io_init = types.MethodType(io_module.init, self)
         self.io_write_buffer = types.MethodType(io_module.write_buffer, self)
         self.io_close = types.MethodType(io_module.close, self)
         self.io_import_file = types.MethodType(io_module.import_file, self)
         self.io_import_file_xarray = types.MethodType(
-            io_module.import_file_xarray, self)
+            io_module.import_file_xarray, self
+        )
 
         # Set configuration options
-        self._add_config({
-            # type, default, min, max, enum, important, value, units, description
-            'general:coastline_action': {
-                'type':
-                'enum',
-                'enum': ['none', 'stranding', 'previous'],
-                'default':
-                'stranding',
-                'level':
-                CONFIG_LEVEL_BASIC,
-                'description':
-                'None means that objects may also move over land. '
-                'stranding means that objects are deactivated if they hit land. '
-                'previous means that objects will move back to the previous location '
-                'if they hit land'
-            },
-            'general:time_step_minutes': {
-                'type':
-                'float',
-                'min':
-                .01,
-                'max':
-                1440,
-                'default':
-                60,
-                'units':
-                'minutes',
-                'level':
-                CONFIG_LEVEL_BASIC,
-                'description':
-                'Calculation time step used for the simulation. The output time step may '
-                'be equal or larger than this.'
-            },
-            'general:time_step_output_minutes': {
-                'type':
-                'float',
-                'min':
-                1,
-                'max':
-                1440,
-                'default':
-                None,
-                'units':
-                'minutes',
-                'level':
-                CONFIG_LEVEL_BASIC,
-                'description':
-                'Output time step, i.e. the interval at which output is saved. This must be larger than '
-                'the calculation time step, and be an integer multiple of this.'
-            },
-            'seed:ocean_only': {
-                'type':
-                'bool',
-                'default':
-                True,
-                'description':
-                'If True, elements seeded on land will be moved to the closest '
-                'position in ocean',
-                'level':
-                CONFIG_LEVEL_ADVANCED
-            },
-            'seed:number': {
-                'type': 'int',
-                'default': 1,
-                'min': 1,
-                'max': 100000000,
-                'units': 1,
-                'description': 'The number of elements for the simulation.',
-                'level': CONFIG_LEVEL_BASIC
-            },
-            'drift:max_age_seconds': {
-                'type': 'float',
-                'default': None,
-                'min': 0,
-                'max': np.inf,
-                'units': 'seconds',
-                'description':
-                'Elements will be deactivated when this age is reached',
-                'level': CONFIG_LEVEL_ADVANCED
-            },
-            'drift:advection_scheme': {
-                'type':
-                'enum',
-                'enum': ['euler', 'runge-kutta', 'runge-kutta4'],
-                'default':
-                'euler',
-                'level':
-                CONFIG_LEVEL_ADVANCED,
-                'description':
-                'Numerical advection scheme for ocean current advection'
-            },
-            'drift:horizontal_diffusivity': {
-                'type': 'float',
-                'default': 0,
-                'min': 0,
-                'max': 100000,
-                'units': 'm2/s',
-                'description': 'Add horizontal diffusivity (random walk)',
-                'level': CONFIG_LEVEL_BASIC
-            },
-            'drift:wind_uncertainty': {
-                'type': 'float',
-                'default': 0,
-                'min': 0,
-                'max': 5,
-                'units': 'm/s',
-                'description':
-                'Add gaussian perturbation with this standard deviation to wind components at each time step.',
-                'level': CONFIG_LEVEL_ADVANCED
-            },
-            'drift:relative_wind': {
-                'type': 'bool',
-                'default': False,
-                'description':
-                'If True, wind drift is calculated for absolute wind (wind vector minus ocean surface current vector).',
-                'level': CONFIG_LEVEL_ADVANCED
-            },
-            'drift:deactivate_north_of': {
-                'type': 'float',
-                'default': None,
-                'min': -90,
-                'max': 90,
-                'units': 'degrees',
-                'description':
-                'Elements are deactivated if the move further north than this limit',
-                'level': CONFIG_LEVEL_ADVANCED
-            },
-            'drift:deactivate_south_of': {
-                'type': 'float',
-                'default': None,
-                'min': -90,
-                'max': 90,
-                'units': 'degrees',
-                'description':
-                'Elements are deactivated if the move further south than this limit',
-                'level': CONFIG_LEVEL_ADVANCED
-            },
-            'drift:deactivate_east_of': {
-                'type': 'float',
-                'default': None,
-                'min': -360,
-                'max': 360,
-                'units': 'degrees',
-                'description':
-                'Elements are deactivated if the move further east than this limit',
-                'level': CONFIG_LEVEL_ADVANCED
-            },
-            'drift:deactivate_west_of': {
-                'type': 'float',
-                'default': None,
-                'min': -360,
-                'max': 360,
-                'units': 'degrees',
-                'description':
-                'Elements are deactivated if the move further west than this limit',
-                'level': CONFIG_LEVEL_ADVANCED
-            },
-            'readers:max_number_of_fails': {
-                'type': 'int',
-                'default': 1,
-                'min': 0,
-                'max': 1e6,
-                'units': 'number',
-                'description':
-                'Readers are discarded if they fail (e.g. corrupted data, og hanging servers) move than this number of times',
-                'level': CONFIG_LEVEL_ADVANCED
-            },
-        })
+        self._add_config(
+            {
+                # type, default, min, max, enum, important, value, units, description
+                "general:coastline_action": {
+                    "type": "enum",
+                    "enum": ["none", "stranding", "previous"],
+                    "default": "stranding",
+                    "level": CONFIG_LEVEL_BASIC,
+                    "description": "None means that objects may also move over land. "
+                    "stranding means that objects are deactivated if they hit land. "
+                    "previous means that objects will move back to the previous location "
+                    "if they hit land",
+                },
+                "general:time_step_minutes": {
+                    "type": "float",
+                    "min": 0.01,
+                    "max": 1440,
+                    "default": 60,
+                    "units": "minutes",
+                    "level": CONFIG_LEVEL_BASIC,
+                    "description": "Calculation time step used for the simulation. The output time step may "
+                    "be equal or larger than this.",
+                },
+                "general:time_step_output_minutes": {
+                    "type": "float",
+                    "min": 1,
+                    "max": 1440,
+                    "default": None,
+                    "units": "minutes",
+                    "level": CONFIG_LEVEL_BASIC,
+                    "description": "Output time step, i.e. the interval at which output is saved. This must be larger than "
+                    "the calculation time step, and be an integer multiple of this.",
+                },
+                "seed:ocean_only": {
+                    "type": "bool",
+                    "default": True,
+                    "description": "If True, elements seeded on land will be moved to the closest "
+                    "position in ocean",
+                    "level": CONFIG_LEVEL_ADVANCED,
+                },
+                "seed:number": {
+                    "type": "int",
+                    "default": 1,
+                    "min": 1,
+                    "max": 100000000,
+                    "units": 1,
+                    "description": "The number of elements for the simulation.",
+                    "level": CONFIG_LEVEL_BASIC,
+                },
+                "drift:max_age_seconds": {
+                    "type": "float",
+                    "default": None,
+                    "min": 0,
+                    "max": np.inf,
+                    "units": "seconds",
+                    "description": "Elements will be deactivated when this age is reached",
+                    "level": CONFIG_LEVEL_ADVANCED,
+                },
+                "drift:advection_scheme": {
+                    "type": "enum",
+                    "enum": ["euler", "runge-kutta", "runge-kutta4"],
+                    "default": "euler",
+                    "level": CONFIG_LEVEL_ADVANCED,
+                    "description": "Numerical advection scheme for ocean current advection",
+                },
+                "drift:horizontal_diffusivity": {
+                    "type": "float",
+                    "default": 0,
+                    "min": 0,
+                    "max": 100000,
+                    "units": "m2/s",
+                    "description": "Add horizontal diffusivity (random walk)",
+                    "level": CONFIG_LEVEL_BASIC,
+                },
+                "drift:wind_uncertainty": {
+                    "type": "float",
+                    "default": 0,
+                    "min": 0,
+                    "max": 5,
+                    "units": "m/s",
+                    "description": "Add gaussian perturbation with this standard deviation to wind components at each time step.",
+                    "level": CONFIG_LEVEL_ADVANCED,
+                },
+                "drift:relative_wind": {
+                    "type": "bool",
+                    "default": False,
+                    "description": "If True, wind drift is calculated for absolute wind (wind vector minus ocean surface current vector).",
+                    "level": CONFIG_LEVEL_ADVANCED,
+                },
+                "drift:deactivate_north_of": {
+                    "type": "float",
+                    "default": None,
+                    "min": -90,
+                    "max": 90,
+                    "units": "degrees",
+                    "description": "Elements are deactivated if the move further north than this limit",
+                    "level": CONFIG_LEVEL_ADVANCED,
+                },
+                "drift:deactivate_south_of": {
+                    "type": "float",
+                    "default": None,
+                    "min": -90,
+                    "max": 90,
+                    "units": "degrees",
+                    "description": "Elements are deactivated if the move further south than this limit",
+                    "level": CONFIG_LEVEL_ADVANCED,
+                },
+                "drift:deactivate_east_of": {
+                    "type": "float",
+                    "default": None,
+                    "min": -360,
+                    "max": 360,
+                    "units": "degrees",
+                    "description": "Elements are deactivated if the move further east than this limit",
+                    "level": CONFIG_LEVEL_ADVANCED,
+                },
+                "drift:deactivate_west_of": {
+                    "type": "float",
+                    "default": None,
+                    "min": -360,
+                    "max": 360,
+                    "units": "degrees",
+                    "description": "Elements are deactivated if the move further west than this limit",
+                    "level": CONFIG_LEVEL_ADVANCED,
+                },
+                "readers:max_number_of_fails": {
+                    "type": "int",
+                    "default": 1,
+                    "min": 0,
+                    "max": 1e6,
+                    "units": "number",
+                    "description": "Readers are discarded if they fail (e.g. corrupted data, og hanging servers) move than this number of times",
+                    "level": CONFIG_LEVEL_ADVANCED,
+                },
+            }
+        )
 
         # Add default element properties to config
         c = {}
         for p in self.ElementType.variables:
             v = self.ElementType.variables[p]
-            if 'seed' in v and v['seed'] is False:
+            if "seed" in v and v["seed"] is False:
                 continue  # Properties which may not be provided by user
-            minval = v['min'] if 'min' in v else None
-            maxval = v['max'] if 'max' in v else None
-            units = v['units'] if 'units' in v else None
-            c['seed:%s' % p] = {
-                'type':
-                v['type'] if 'type' in v else 'float',
-                'min':
-                v['min'] if 'min' in v else None,
-                'max':
-                v['max'] if 'max' in v else None,
-                'units':
-                v['units'] if 'units' in v else None,
-                'default':
-                v['default'] if 'default' in v else None,
-                'description':
-                v['description']
-                if 'description' in v else 'Seeding value of %s' % p,
-                'level':
-                v['level'] if 'level' in v else CONFIG_LEVEL_ADVANCED
+            minval = v["min"] if "min" in v else None
+            maxval = v["max"] if "max" in v else None
+            units = v["units"] if "units" in v else None
+            c["seed:%s" % p] = {
+                "type": v["type"] if "type" in v else "float",
+                "min": v["min"] if "min" in v else None,
+                "max": v["max"] if "max" in v else None,
+                "units": v["units"] if "units" in v else None,
+                "default": v["default"] if "default" in v else None,
+                "description": (
+                    v["description"]
+                    if "description" in v
+                    else "Seeding value of %s" % p
+                ),
+                "level": v["level"] if "level" in v else CONFIG_LEVEL_ADVANCED,
             }
         self._add_config(c)
 
@@ -509,33 +498,38 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         # Find variables which require profiles
         self.required_profiles = [
-            var for var in self.required_variables
-            if 'profiles' in self.required_variables[var]
-            and self.required_variables[var]['profiles'] is True
+            var
+            for var in self.required_variables
+            if "profiles" in self.required_variables[var]
+            and self.required_variables[var]["profiles"] is True
         ]
 
         # Find variables which are desired, but not required
         self.desired_variables = [
-            var for var in self.required_variables
-            if 'important' in self.required_variables[var]
-            and self.required_variables[var]['important'] is False
+            var
+            for var in self.required_variables
+            if "important" in self.required_variables[var]
+            and self.required_variables[var]["important"] is False
         ]
 
-        self.timer_start('total time')
-        self.timer_start('configuration')
+        self.timer_start("total time")
+        self.timer_start("configuration")
 
-        self.add_metadata('opendrift_version', opendrift.__version__)
-        logger.info('OpenDriftSimulation initialised (version %s)' %
-                    opendrift.version.version_or_git())
+        self.add_metadata("opendrift_version", opendrift.__version__)
+        logger.info(
+            "OpenDriftSimulation initialised (version %s)"
+            % opendrift.version.version_or_git()
+        )
 
         # Check if dependencies are outdated
         import importlib
+
         if importlib.util.find_spec("cmocean") is None:
-            logger.warning('#' * 82)
+            logger.warning("#" * 82)
             logger.warning(
-                'Dependencies are outdated, please update with: conda env update -f environment.yml'
+                "Dependencies are outdated, please update with: conda env update -f environment.yml"
             )
-            logger.warning('#' * 82)
+            logger.warning("#" * 82)
 
     def clone(self):
         c = self.__class__()
@@ -548,8 +542,9 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         return c
 
-    @require_mode(mode=Mode.Config,
-                  error='Cannot set config after elements have been seeded')
+    @require_mode(
+        mode=Mode.Config, error="Cannot set config after elements have been seeded"
+    )
     @functools.wraps(Configurable.set_config)
     def set_config(self, *args, **kwargs):
         return Configurable.set_config(self, *args, **kwargs)
@@ -560,20 +555,25 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         """
         This method allows setting config values that are passed as seed arguments. The environment is already prepared before this, so make sure that nothing is changed that requires the environment to be re-initialized.
         """
-        if not key.startswith('seed'):
+        if not key.startswith("seed"):
             raise ValueError("This method is only allowed for setting seed arguments.")
 
         # check that the oil_type is only set once
-        if key == 'seed:oil_type' and self.num_elements_scheduled() > 0:
-            if value != self.get_config('seed:oil_type'):
-                raise WrongMode(Mode.Config, self.mode, msg=f"Cannot change the oil type after elements have been seeded: {self.get_config('seed:oil_type')} -> {value}")
+        if key == "seed:oil_type" and self.num_elements_scheduled() > 0:
+            if value != self.get_config("seed:oil_type"):
+                raise WrongMode(
+                    Mode.Config,
+                    self.mode,
+                    msg=f"Cannot change the oil type after elements have been seeded: {self.get_config('seed:oil_type')} -> {value}",
+                )
 
         return Configurable.set_config(self, key, value)
 
     def add_metadata(self, key, value):
         """Add item to metadata dictionary, for export as netCDF global attributes"""
-        if not hasattr(self, 'metadata_dict'):
+        if not hasattr(self, "metadata_dict"):
             from collections import OrderedDict
+
             self.metadata_dict = OrderedDict()
         self.metadata_dict[key] = value
 
@@ -583,12 +583,12 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
     @require_mode(mode=Mode.Config)
     def add_readers_from_list(self, *args, **kwargs):
-        '''Make readers from a list of URLs or paths to netCDF datasets'''
+        """Make readers from a list of URLs or paths to netCDF datasets"""
         self.env.add_readers_from_list(*args, **kwargs)
 
     @require_mode(mode=Mode.Config)
     def add_readers_from_file(self, *args, **kwargs):
-        '''Make readers from a file containing list of URLs or paths to netCDF datasets'''
+        """Make readers from a file containing list of URLs or paths to netCDF datasets"""
         self.env.add_readers_from_file(*args, **kwargs)
 
     def prepare_run(self):
@@ -596,10 +596,11 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
     def store_present_positions(self, IDs=None, lons=None, lats=None):
         """Store present element positions, in case they shall be moved back"""
-        if self.get_config('general:coastline_action') == 'previous' or (
-                'general:seafloor_action' in self._config
-                and self.get_config('general:seafloor_action') == 'previous'):
-            if not hasattr(self, 'previous_lon'):
+        if self.get_config("general:coastline_action") == "previous" or (
+            "general:seafloor_action" in self._config
+            and self.get_config("general:seafloor_action") == "previous"
+        ):
+            if not hasattr(self, "previous_lon"):
                 self.previous_lon = np.ma.masked_all(self.num_elements_total())
                 self.previous_lat = np.ma.masked_all(self.num_elements_total())
             if IDs is None:
@@ -619,103 +620,104 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
     def store_previous_variables(self):
         """Store some environment variables, for access at next time step"""
 
-        if not hasattr(self, 'store_previous'):
+        if not hasattr(self, "store_previous"):
             return
-        if not hasattr(self, 'variables_previous'):
+        if not hasattr(self, "variables_previous"):
             # Create ndarray to store previous variables
             dtype = [(var, np.float32) for var in self.store_previous]
-            self.variables_previous = np.array(np.full(
-                self.num_elements_total(), np.nan),
-                                               dtype=dtype)
+            self.variables_previous = np.array(
+                np.full(self.num_elements_total(), np.nan), dtype=dtype
+            )
 
         # Copying variables_previous to environment_previous
-        self.environment_previous = self.variables_previous[self.elements.ID -
-                                                            1]
+        self.environment_previous = self.variables_previous[self.elements.ID - 1]
 
         # Use new values for new elements which have no previous value
         for var in self.store_previous:
             undefined = np.isnan(self.environment_previous[var])
-            self.environment_previous[var][undefined] = getattr(
-                self.environment, var)[undefined]
+            self.environment_previous[var][undefined] = getattr(self.environment, var)[
+                undefined
+            ]
 
         self.environment_previous = self.environment_previous.view(np.recarray)
 
         for var in self.store_previous:
             self.variables_previous[var][self.elements.ID - 1] = getattr(
-                self.environment, var)
+                self.environment, var
+            )
 
     def interact_with_coastline(self, final=False):
         """Coastline interaction according to configuration setting"""
         if self.num_elements_active() == 0:
             return
-        i = self.get_config('general:coastline_action')
-        if not hasattr(self, 'environment') or not hasattr(
-                self.environment, 'land_binary_mask'):
+        i = self.get_config("general:coastline_action")
+        if not hasattr(self, "environment") or not hasattr(
+            self.environment, "land_binary_mask"
+        ):
             return
-        if i == 'none':  # Do nothing
+        if i == "none":  # Do nothing
             return
         if final is True:  # Get land_binary_mask for final location
-            en, en_prof, missing = \
-                self.env.get_environment(['land_binary_mask'],
-                                     self.time,
-                                     self.elements.lon,
-                                     self.elements.lat,
-                                     self.elements.z,
-                                     None)
+            en, en_prof, missing = self.env.get_environment(
+                ["land_binary_mask"],
+                self.time,
+                self.elements.lon,
+                self.elements.lat,
+                self.elements.z,
+                None,
+            )
             self.environment.land_binary_mask = en.land_binary_mask
 
-        if i == 'stranding':  # Deactivate elements on land, but not in air
-            self.deactivate_elements((self.environment.land_binary_mask == 1) &
-                                     (self.elements.z <= 0),
-                                     reason='stranded')
-        elif i == 'previous':  # Go back to previous position (in water)
+        if i == "stranding":  # Deactivate elements on land, but not in air
+            self.deactivate_elements(
+                (self.environment.land_binary_mask == 1) & (self.elements.z <= 0),
+                reason="stranded",
+            )
+        elif i == "previous":  # Go back to previous position (in water)
             if self.newly_seeded_IDs is not None:
                 self.deactivate_elements(
-                    (self.environment.land_binary_mask == 1) &
-                    (self.elements.age_seconds
-                     == self.time_step.total_seconds()),
-                    reason='seeded_on_land')
+                    (self.environment.land_binary_mask == 1)
+                    & (self.elements.age_seconds == self.time_step.total_seconds()),
+                    reason="seeded_on_land",
+                )
             on_land = np.where(self.environment.land_binary_mask == 1)[0]
             if len(on_land) == 0:
-                logger.debug('No elements hit coastline.')
+                logger.debug("No elements hit coastline.")
             else:
-                logger.debug('%s elements hit coastline, '
-                             'moving back to water' % len(on_land))
+                logger.debug(
+                    "%s elements hit coastline, " "moving back to water" % len(on_land)
+                )
                 on_land_ID = self.elements.ID[on_land]
-                self.elements.lon[on_land] = \
-                    np.copy(self.previous_lon[on_land_ID - 1])
-                self.elements.lat[on_land] = \
-                    np.copy(self.previous_lat[on_land_ID - 1])
+                self.elements.lon[on_land] = np.copy(self.previous_lon[on_land_ID - 1])
+                self.elements.lat[on_land] = np.copy(self.previous_lat[on_land_ID - 1])
                 self.environment.land_binary_mask[on_land] = 0
 
     def interact_with_seafloor(self):
         """Seafloor interaction according to configuration setting"""
         if self.num_elements_active() == 0:
             return
-        if 'sea_floor_depth_below_sea_level' not in self.env.priority_list:
+        if "sea_floor_depth_below_sea_level" not in self.env.priority_list:
             return
         sea_floor_depth = self.sea_floor_depth()
         below = np.where(self.elements.z < -sea_floor_depth)[0]
         if len(below) == 0:
-            logger.debug('No elements hit seafloor.')
+            logger.debug("No elements hit seafloor.")
             return
 
-        i = self.get_config('general:seafloor_action')
-        if i == 'lift_to_seafloor':
-            logger.debug('Lifting %s elements to seafloor.' % len(below))
+        i = self.get_config("general:seafloor_action")
+        if i == "lift_to_seafloor":
+            logger.debug("Lifting %s elements to seafloor." % len(below))
             self.elements.z[below] = -sea_floor_depth[below]
-        elif i == 'deactivate':
-            self.deactivate_elements(self.elements.z < -sea_floor_depth,
-                                     reason='seafloor')
+        elif i == "deactivate":
+            self.deactivate_elements(
+                self.elements.z < -sea_floor_depth, reason="seafloor"
+            )
             self.elements.z[below] = -sea_floor_depth[below]
-        elif i == 'previous':  # Go back to previous position (in water)
-            logger.warning('%s elements hit seafloor, '
-                           'moving back ' % len(below))
+        elif i == "previous":  # Go back to previous position (in water)
+            logger.warning("%s elements hit seafloor, " "moving back " % len(below))
             below_ID = self.elements.ID[below]
-            self.elements.lon[below] = \
-                np.copy(self.previous_lon[below_ID - 1])
-            self.elements.lat[below] = \
-                np.copy(self.previous_lat[below_ID - 1])
+            self.elements.lon[below] = np.copy(self.previous_lon[below_ID - 1])
+            self.elements.lat[below] = np.copy(self.previous_lat[below_ID - 1])
 
     @abstractmethod
     def update(self):
@@ -738,58 +740,64 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
     def test_data_folder(self):
         import opendrift
-        return os.path.abspath(
-            os.path.join(os.path.dirname(opendrift.__file__), '..', 'tests',
-                         'test_data')) + os.path.sep
+
+        return (
+            os.path.abspath(
+                os.path.join(
+                    os.path.dirname(opendrift.__file__), "..", "tests", "test_data"
+                )
+            )
+            + os.path.sep
+        )
 
     def performance(self):
-        '''Report the time spent on various tasks'''
+        """Report the time spent on various tasks"""
 
-        outStr = '--------------------\n'
-        outStr += 'Reader performance:\n'
+        outStr = "--------------------\n"
+        outStr += "Reader performance:\n"
         for r in self.env.readers:
             reader = self.env.readers[r]
             if reader.is_lazy:
                 continue
-            outStr += '--------------------\n'
-            outStr += r + '\n'
+            outStr += "--------------------\n"
+            outStr += r + "\n"
             outStr += reader.performance()
 
-        outStr += '--------------------\n'
-        outStr += 'Performance:\n'
+        outStr += "--------------------\n"
+        outStr += "Performance:\n"
         for category, time in self.timing.items():
-            timestr = str(time)[0:str(time).find('.') + 2]
+            timestr = str(time)[0 : str(time).find(".") + 2]
             for i, c in enumerate(timestr):
-                if c in '123456789.':
+                if c in "123456789.":
                     timestr = timestr[i:]  # Strip leading 0 and :
-                    if c == '.':
-                        timestr = '0' + timestr
+                    if c == ".":
+                        timestr = "0" + timestr
                     break
-            parts = category.split(':')
-            indent = '  ' * (len(parts) - 1)
+            parts = category.split(":")
+            indent = "  " * (len(parts) - 1)
             category = parts[-1]
-            category = category.replace('<colon>', ':')
-            outStr += '%s%7s %s\n' % (indent, timestr, category)
+            category = category.replace("<colon>", ":")
+            outStr += "%s%7s %s\n" % (indent, timestr, category)
 
-        outStr += '--------------------\n'
+        outStr += "--------------------\n"
         return outStr
 
     def num_elements_active(self):
         """The number of active elements."""
-        if hasattr(self, 'elements'):
+        if hasattr(self, "elements"):
             return len(self.elements)
         else:
             return 0
 
     def num_elements_deactivated(self):
         """The number of deactivated elements."""
-        if hasattr(self, 'elements_deactivated'):
+        if hasattr(self, "elements_deactivated"):
             return len(self.elements_deactivated)
         else:
             return 0
 
     def num_elements_scheduled(self):
-        if hasattr(self, 'elements_scheduled'):
+        if hasattr(self, "elements_scheduled"):
             return len(self.elements_scheduled)
         else:
             return 0
@@ -816,52 +824,56 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         if len(time) == 1 and len(elements) > 1:
             time = time * len(elements)
 
-        if not hasattr(self, 'elements_scheduled'):
+        if not hasattr(self, "elements_scheduled"):
             self.elements_scheduled = elements
             self.elements_scheduled_time = np.array(time)
             # We start simulation at time of release of first element:
             self.start_time = time[0]
             self.elements_scheduled.ID = np.arange(1, len(elements) + 1)
         else:
-            elements.ID = np.arange(self.num_elements_scheduled() + 1,
-                                    self.num_elements_scheduled() + 1 +
-                                    len(elements))  # Increase ID successively
+            elements.ID = np.arange(
+                self.num_elements_scheduled() + 1,
+                self.num_elements_scheduled() + 1 + len(elements),
+            )  # Increase ID successively
             self.elements_scheduled.extend(elements)
             self.elements_scheduled_time = np.append(
-                self.elements_scheduled_time, np.array(time))
+                self.elements_scheduled_time, np.array(time)
+            )
 
         min_time = np.min(time)
-        if hasattr(self, 'start_time'):
+        if hasattr(self, "start_time"):
             if min_time < self.start_time:
                 self.start_time = min_time
-                logger.debug('Setting simulation start time to %s' %
-                             str(min_time))
+                logger.debug("Setting simulation start time to %s" % str(min_time))
         else:
             self.start_time = min_time
-            logger.debug('Setting simulation start time to %s' % str(min_time))
+            logger.debug("Setting simulation start time to %s" % str(min_time))
 
     def release_elements(self):
         """Activate elements which are scheduled within following timestep."""
 
         logger.debug(
-            'to be seeded: %s, already seeded %s' %
-            (len(self.elements_scheduled), self.num_elements_activated()))
+            "to be seeded: %s, already seeded %s"
+            % (len(self.elements_scheduled), self.num_elements_activated())
+        )
         if len(self.elements_scheduled) == 0:
             return
         if self.time_step.days >= 0:
-            indices = (self.elements_scheduled_time >= self.time) & \
-                      (self.elements_scheduled_time <
-                       self.time + self.time_step)
+            indices = (self.elements_scheduled_time >= self.time) & (
+                self.elements_scheduled_time < self.time + self.time_step
+            )
         else:
-            indices = (self.elements_scheduled_time <= self.time) & \
-                      (self.elements_scheduled_time >
-                       self.time + self.time_step)
-        self.store_present_positions(self.elements_scheduled.ID[indices],
-                                     self.elements_scheduled.lon[indices],
-                                     self.elements_scheduled.lat[indices])
+            indices = (self.elements_scheduled_time <= self.time) & (
+                self.elements_scheduled_time > self.time + self.time_step
+            )
+        self.store_present_positions(
+            self.elements_scheduled.ID[indices],
+            self.elements_scheduled.lon[indices],
+            self.elements_scheduled.lat[indices],
+        )
         self.elements_scheduled.move_elements(self.elements, indices)
         self.elements_scheduled_time = self.elements_scheduled_time[~indices]
-        logger.debug('Released %i new elements.' % np.sum(indices))
+        logger.debug("Released %i new elements." % np.sum(indices))
 
     def closest_ocean_points(self, lon, lat):
         """Return the closest ocean points for given lon, lat"""
@@ -873,37 +885,42 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         lonmax = lon.max() + deltalon * numbuffer
         latmin = lat.min() - deltalat * numbuffer
         latmax = lat.max() + deltalat * numbuffer
-        if not 'land_binary_mask' in self.env.priority_list:
-            logger.info('No land reader added, '
-                        'making a temporary landmask reader')
+        if not "land_binary_mask" in self.env.priority_list:
+            logger.info("No land reader added, " "making a temporary landmask reader")
             from opendrift.models.oceandrift import OceanDrift
+
             reader_landmask = reader_global_landmask.Reader()
-            seed_state = np.random.get_state(
+            seed_state = (
+                np.random.get_state()
             )  # Do not alter current random number generator
-            o = OceanDrift(loglevel='custom')
+            o = OceanDrift(loglevel="custom")
             np.random.set_state(seed_state)
-            if hasattr(self, 'simulation_extent'):
+            if hasattr(self, "simulation_extent"):
                 o.simulation_extent = self.simulation_extent
             o.env.add_reader(reader_landmask)
             o.env.finalize()  # This is not env of the main simulation
             land_reader = reader_landmask
         else:
-            logger.info('Using existing reader for land_binary_mask')
-            land_reader_name = self.env.priority_list['land_binary_mask'][0]
+            logger.info("Using existing reader for land_binary_mask")
+            land_reader_name = self.env.priority_list["land_binary_mask"][0]
             land_reader = self.env.readers[land_reader_name]
             o = self
 
-        land = o.env.get_environment(['land_binary_mask'],
-                                     lon=lon,
-                                     lat=lat,
-                                     z=0 * lon,
-                                     time=land_reader.start_time,
-                                     profiles=None)[0]['land_binary_mask']
+        land = o.env.get_environment(
+            ["land_binary_mask"],
+            lon=lon,
+            lat=lat,
+            z=0 * lon,
+            time=land_reader.start_time,
+            profiles=None,
+        )[0]["land_binary_mask"]
         if land.max() == 0:
-            logger.info('All points are in ocean')
+            logger.info("All points are in ocean")
             return lon, lat
-        logger.info('Moving %i out of %i points from land to water' %
-                    (np.sum(land != 0), len(lon)))
+        logger.info(
+            "Moving %i out of %i points from land to water"
+            % (np.sum(land != 0), len(lon))
+        )
         landlons = lon[land != 0]
         landlats = lat[land != 0]
         longrid = np.arange(lonmin, lonmax, deltalon)
@@ -915,20 +932,21 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         latgrid_covered = land_reader.covers_positions(longrid, latgrid)[0]
         longrid = longrid[latgrid_covered]
         latgrid = latgrid[latgrid_covered]
-        landgrid = o.env.get_environment(['land_binary_mask'],
-                                         lon=longrid,
-                                         lat=latgrid,
-                                         z=0 * longrid,
-                                         time=land_reader.start_time,
-                                         profiles=None)[0]['land_binary_mask']
+        landgrid = o.env.get_environment(
+            ["land_binary_mask"],
+            lon=longrid,
+            lat=latgrid,
+            z=0 * longrid,
+            time=land_reader.start_time,
+            profiles=None,
+        )[0]["land_binary_mask"]
         if landgrid.min() == 1 or np.isnan(landgrid.min()):
-            logger.warning('No ocean pixels nearby, cannot move elements.')
+            logger.warning("No ocean pixels nearby, cannot move elements.")
             return lon, lat
 
         oceangridlons = longrid[landgrid == 0]
         oceangridlats = latgrid[landgrid == 0]
-        tree = scipy.spatial.cKDTree(
-            np.dstack([oceangridlons, oceangridlats])[0])
+        tree = scipy.spatial.cKDTree(np.dstack([oceangridlons, oceangridlats])[0])
         landpoints = np.dstack([landlons, landlats])
         _dist, indices = tree.query(landpoints)
         indices = indices.ravel()
@@ -938,14 +956,9 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         return lon, lat
 
     @require_mode(mode=Mode.Ready)
-    def seed_elements(self,
-                      lon,
-                      lat,
-                      time,
-                      radius=0,
-                      number=None,
-                      radius_type='gaussian',
-                      **kwargs):
+    def seed_elements(
+        self, lon, lat, time, radius=0, number=None, radius_type="gaussian", **kwargs
+    ):
         """Seed elements with given position(s), time and properties.
 
         Arguments:
@@ -977,29 +990,27 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 for which there are no default value must be specified.
         """
 
-        if 'cone' in kwargs:
+        if "cone" in kwargs:
             raise ValueError(
-                'Keyword *cone* for seed_elements is deprecated, use seed_cone() instead.'
+                "Keyword *cone* for seed_elements is deprecated, use seed_cone() instead."
             )
 
         if self.origin_marker is None:
             self.origin_marker = {}
-        if 'origin_marker' in kwargs:
-            origin_marker = kwargs['origin_marker']
+        if "origin_marker" in kwargs:
+            origin_marker = kwargs["origin_marker"]
         else:
             origin_marker = len(self.origin_marker)
-        if 'origin_marker_name' in kwargs:
-            origin_marker_name = kwargs['origin_marker_name']
-            del kwargs['origin_marker_name']
+        if "origin_marker_name" in kwargs:
+            origin_marker_name = kwargs["origin_marker_name"]
+            del kwargs["origin_marker_name"]
         else:
-            origin_marker_name = 'Seed %d' % len(self.origin_marker)
-        if not 'origin_marker' in kwargs:
-            kwargs['origin_marker'] = origin_marker
-        if '_' in origin_marker_name:
-            raise ValueError(
-                'Underscore (_) not allowed in origin_marker_name')
-        self.origin_marker[str(origin_marker)] = origin_marker_name.replace(
-            ' ', '_')
+            origin_marker_name = "Seed %d" % len(self.origin_marker)
+        if not "origin_marker" in kwargs:
+            kwargs["origin_marker"] = origin_marker
+        if "_" in origin_marker_name:
+            raise ValueError("Underscore (_) not allowed in origin_marker_name")
+        self.origin_marker[str(origin_marker)] = origin_marker_name.replace(" ", "_")
 
         lon = np.atleast_1d(lon).ravel()
         lat = np.atleast_1d(lat).ravel()
@@ -1007,94 +1018,101 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         time = np.atleast_1d(time)
 
         if lat.max() > 90 or lat.min() < -90:
-            raise ValueError('Latitude must be between -90 and 90 degrees')
+            raise ValueError("Latitude must be between -90 and 90 degrees")
 
         if len(lon) != len(lat):
-            raise ValueError('Lon and lat must have same lengths')
+            raise ValueError("Lon and lat must have same lengths")
 
         if len(lon) > 1:
             if number is not None and number != len(lon):
                 raise ValueError(
-                    'Lon and lat have length %s, but number is %s' %
-                    (len(lon), number))
+                    "Lon and lat have length %s, but number is %s" % (len(lon), number)
+                )
             number = len(lon)
         else:
             if number is None:
                 if len(time) > 2:
                     number = len(time)  # Interpreting as time series
                 else:
-                    number = self.get_config('seed:number')
+                    number = self.get_config("seed:number")
             lon = lon * np.ones(number)
             lat = lat * np.ones(number)
 
         if len(time) != number and len(time) > 1:
             if len(time) == 2:  # start -> end
-                td = (time[1] - time[0]) / (number - 1
-                                            )  # timestep between points
+                td = (time[1] - time[0]) / (number - 1)  # timestep between points
                 time = [time[0] + i * td for i in range(number)]
             else:
                 raise ValueError(
-                    'Time array has length %s, must be 1, 2 or %s' %
-                    (len(time), number))
+                    "Time array has length %s, must be 1, 2 or %s" % (len(time), number)
+                )
 
         # Add radius / perturbation
         if radius.max() > 0:
-            geod = pyproj.Geod(ellps='WGS84')
-            if radius_type == 'gaussian':
+            geod = pyproj.Geod(ellps="WGS84")
+            if radius_type == "gaussian":
                 x = np.random.randn(np.sum(number)) * radius
                 y = np.random.randn(np.sum(number)) * radius
                 az = np.degrees(np.arctan2(x, y))
                 dist = np.sqrt(x * x + y * y)
-            elif radius_type == 'uniform':
+            elif radius_type == "uniform":
                 az = np.random.rand(np.sum(number)) * 360
-                dist = np.sqrt(np.random.uniform(0, 1,
-                                                 np.sum(number))) * radius
+                dist = np.sqrt(np.random.uniform(0, 1, np.sum(number))) * radius
             lon, lat, az = geod.fwd(lon, lat, az, dist, radians=False)
 
         # If z is 'seafloor'
-        if not 'z' in kwargs or kwargs['z'] is None:
-            if 'seed:seafloor' in self._config:
-                if self.get_config('seed:seafloor') is True:
-                    kwargs['z'] = 'seafloor'
-                    logger.debug('Seafloor is selected, neglecting z')
-        if 'z' in kwargs and isinstance(kwargs['z'], str) \
-                and kwargs['z'][0:8] == 'seafloor':
+        if not "z" in kwargs or kwargs["z"] is None:
+            if "seed:seafloor" in self._config:
+                if self.get_config("seed:seafloor") is True:
+                    kwargs["z"] = "seafloor"
+                    logger.debug("Seafloor is selected, neglecting z")
+        if (
+            "z" in kwargs
+            and isinstance(kwargs["z"], str)
+            and kwargs["z"][0:8] == "seafloor"
+        ):
             # We need to fetch seafloor depth from reader
             seafloor_constant = self.get_config(
-                'environment:constant:sea_floor_depth_below_sea_level')
+                "environment:constant:sea_floor_depth_below_sea_level"
+            )
             seafloor_fallback = self.get_config(
-                'environment:fallback:sea_floor_depth_below_sea_level')
+                "environment:fallback:sea_floor_depth_below_sea_level"
+            )
             if seafloor_constant is not None:
-                env = {
-                    'sea_floor_depth_below_sea_level':
-                    np.array(seafloor_constant)
-                }
-            elif ('sea_floor_depth_below_sea_level'
-                  in self.env.priority_list) or len(self.env._lazy_readers()):
-                if not hasattr(self, 'time'):
+                env = {"sea_floor_depth_below_sea_level": np.array(seafloor_constant)}
+            elif ("sea_floor_depth_below_sea_level" in self.env.priority_list) or len(
+                self.env._lazy_readers()
+            ):
+                if not hasattr(self, "time"):
                     self.time = time[0]
-                env, env_profiles, missing = \
-                    self.env.get_environment(['sea_floor_depth_below_sea_level'],
-                                         time=time[0], lon=lon, lat=lat,
-                                         z=0*lon, profiles=None)
+                env, env_profiles, missing = self.env.get_environment(
+                    ["sea_floor_depth_below_sea_level"],
+                    time=time[0],
+                    lon=lon,
+                    lat=lat,
+                    z=0 * lon,
+                    profiles=None,
+                )
             elif seafloor_fallback is not None:
-                env = {
-                    'sea_floor_depth_below_sea_level':
-                    np.array(seafloor_fallback)
-                }
+                env = {"sea_floor_depth_below_sea_level": np.array(seafloor_fallback)}
             else:
-                raise ValueError('A reader providing the variable '
-                                 'sea_floor_depth_below_sea_level must be '
-                                 'added before seeding elements at seafloor.')
+                raise ValueError(
+                    "A reader providing the variable "
+                    "sea_floor_depth_below_sea_level must be "
+                    "added before seeding elements at seafloor."
+                )
             # Add M meters if given as 'seafloor+M'
-            if len(kwargs['z']) > 8 and kwargs['z'][8] == '+':
-                meters_above_seafloor = float(kwargs['z'][9::])
-                logger.info('Seeding elements %f meters above seafloor' %
-                            meters_above_seafloor)
+            if len(kwargs["z"]) > 8 and kwargs["z"][8] == "+":
+                meters_above_seafloor = float(kwargs["z"][9::])
+                logger.info(
+                    "Seeding elements %f meters above seafloor" % meters_above_seafloor
+                )
             else:
                 meters_above_seafloor = 0
-            kwargs['z'] = \
-                -env['sea_floor_depth_below_sea_level'].astype('float32') + meters_above_seafloor
+            kwargs["z"] = (
+                -env["sea_floor_depth_below_sea_level"].astype("float32")
+                + meters_above_seafloor
+            )
 
         # Creating and scheduling elements
         elements = self.ElementType(lon=lon, lat=lat, **kwargs)
@@ -1125,81 +1143,78 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         """
 
         if number is None:
-            number = self.get_config('seed:number')
+            number = self.get_config("seed:number")
         if number == 1:
             raise ValueError(
-                'For a cone, the number of elements must be at least 2 or more, given is 1'
+                "For a cone, the number of elements must be at least 2 or more, given is 1"
             )
 
         lon = np.atleast_1d(lon).ravel()
         lat = np.atleast_1d(lat).ravel()
         radius = np.atleast_1d(radius).ravel()
         if len(lon) != len(lat):
-            raise ValueError('Lon and lat must have same length (1 or 2)')
+            raise ValueError("Lon and lat must have same length (1 or 2)")
         elif len(lon) > 2:
             raise ValueError(
-                'Lon and lat must have length 1 or 2, given length is %s' %
-                (len(lon)))
+                "Lon and lat must have length 1 or 2, given length is %s" % (len(lon))
+            )
         elif len(lon) == 1:
             lon = lon * np.ones(number)
             lat = lat * np.ones(number)
         elif len(lon) == 2:  # Segment from lon0,lat1 to lon1,lat2
-            geod = pyproj.Geod(ellps='WGS84')
+            geod = pyproj.Geod(ellps="WGS84")
             lonin = lon
             latin = lat
             # Note that npts places points in-between start and end, and does not include these
-            conelonlats = geod.npts(lon[0],
-                                    lat[0],
-                                    lon[1],
-                                    lat[1],
-                                    number,
-                                    radians=False)
+            conelonlats = geod.npts(
+                lon[0], lat[0], lon[1], lat[1], number, radians=False
+            )
             lon, lat = zip(*conelonlats)
 
         if len(radius) > 2:
-            raise ValueError('Seed radius must have length 1 or 2')
+            raise ValueError("Seed radius must have length 1 or 2")
         elif len(radius) == 2:  # Linear increase from r0 to r1
             radius = np.linspace(radius[0], radius[1], number)
 
         if isinstance(time, list) and len(time) == 1:
             time = time[0]
 
-        if hasattr(time, '__len__'):
+        if hasattr(time, "__len__"):
             timespan = [time[0], time[-1]]
         else:
             timespan = [time, time]
 
         radius = radius.astype(np.float32)
-        lonin = lonin if 'lonin' in locals() else [lon.min(), lon.max()]
-        latin = latin if 'latin' in locals() else [lat.min(), lat.max()]
+        lonin = lonin if "lonin" in locals() else [lon.min(), lon.max()]
+        latin = latin if "latin" in locals() else [lat.min(), lat.max()]
 
         self.seed_cone_arguments = {
-            'lon': lonin,
-            'lat': latin,
-            'radius': [float(radius[0]), float(radius[-1])],
-            'time': timespan,
-            'number': number
+            "lon": lonin,
+            "lat": latin,
+            "radius": [float(radius[0]), float(radius[-1])],
+            "time": timespan,
+            "number": number,
         }
 
         # Make GeoJson seeding dict to be saved in netCDF metadata
-        geo = geojson.LineString([(float(lonin[0]), float(latin[0])),
-                                  (float(lonin[1]), float(latin[1]))])
-        seed_defaults = self.get_configspec('seed')
+        geo = geojson.LineString(
+            [(float(lonin[0]), float(latin[0])), (float(lonin[1]), float(latin[1]))]
+        )
+        seed_defaults = self.get_configspec("seed")
         default_seed = {
-            k.split(':')[-1]: seed_defaults[k]['value']
-            for k in seed_defaults
+            k.split(":")[-1]: seed_defaults[k]["value"] for k in seed_defaults
         }
-        if 'seafloor' in default_seed and default_seed['seafloor'] is True:
-            default_seed['z'] = 'seafloor'
+        if "seafloor" in default_seed and default_seed["seafloor"] is True:
+            default_seed["z"] = "seafloor"
         default_seed = {
             **default_seed,
-            **kwargs
+            **kwargs,
         }  # Overwrite with explicitly provided values
         properties = {
-            **default_seed, 'time': [str(timespan[0]),
-                                     str(timespan[1])],
-            'radius': [float(radius[0]), float(radius[-1])],
-            'number': number
+            **default_seed,
+            "time": [str(timespan[0]), str(timespan[1])],
+            "radius": [float(radius[0]), float(radius[-1])],
+            "number": number,
         }
         # convert array to string in case of array input to seed cone
         for key in properties.keys():
@@ -1210,12 +1225,9 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         self.seed_geojson.append(f)
 
         # Forwarding calculated cone points/radii to seed_elements
-        self.seed_elements(lon=lon,
-                           lat=lat,
-                           time=time,
-                           radius=radius,
-                           number=number,
-                           **kwargs)
+        self.seed_elements(
+            lon=lon, lat=lat, time=time, radius=radius, number=number, **kwargs
+        )
 
     @require_mode(mode=Mode.Ready)
     def seed_from_geojson(self, gjson):
@@ -1223,54 +1235,56 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         try:
             gj = geojson.loads(gjson)
         except:
-            raise ValueError('Could not load GeoJSON string: %s' % gjson)
+            raise ValueError("Could not load GeoJSON string: %s" % gjson)
         if not gj.is_valid:
-            raise ValueError('GeoJSON string is not valid: %s' % gj.errors())
+            raise ValueError("GeoJSON string is not valid: %s" % gj.errors())
         # Assuming temporally that g is a Feature, and not a FeatureCollection
-        properties = gj['properties']
-        if 'time' not in properties:
+        properties = gj["properties"]
+        if "time" not in properties:
             raise ValueError('Property "time" is not available')
         kwargs = {}
         for prop in properties:
-            if prop == 'time':
-                t = properties['time']
+            if prop == "time":
+                t = properties["time"]
                 if isinstance(t, list):
                     time = [
                         datetime.fromisoformat(t[0].replace("Z", "+00:00")),
-                        datetime.fromisoformat(t[1].replace("Z", "+00:00"))
+                        datetime.fromisoformat(t[1].replace("Z", "+00:00")),
                     ]
                 else:
                     time = datetime.fromisoformat(t.replace("Z", "+00:00"))
             else:
                 kwargs[prop] = properties[prop]
 
-        geometry = gj['geometry']
+        geometry = gj["geometry"]
 
-        if geometry['type'] == 'Polygon':
+        if geometry["type"] == "Polygon":
             coords = list(geojson.utils.coords(gj))
             lon, lat = zip(*[(c[0], c[1]) for c in coords])
             self.seed_within_polygon(lons=lon, lats=lat, time=time, **kwargs)
-        elif geometry['type'] == 'LineString':
+        elif geometry["type"] == "LineString":
             coords = list(geojson.utils.coords(gj))
             lon, lat = zip(*[(c[0], c[1]) for c in coords])
             self.seed_cone(lon=lon, lat=lat, time=time, **kwargs)
-        elif geometry['type'] == 'Point':
+        elif geometry["type"] == "Point":
             coords = list(geojson.utils.coords(gj))
             lon, lat = zip(*[(c[0], c[1]) for c in coords])
             self.seed_elements(lon=lon, lat=lat, time=time, **kwargs)
         else:
-            raise ValueError('Not yet implemented')
+            raise ValueError("Not yet implemented")
 
     @require_mode(mode=Mode.Ready)
-    def seed_repeated_segment(self,
-                              lons,
-                              lats,
-                              start_time,
-                              end_time,
-                              time_interval=None,
-                              number_per_segment=None,
-                              total_number=None,
-                              **kwargs):
+    def seed_repeated_segment(
+        self,
+        lons,
+        lats,
+        start_time,
+        end_time,
+        time_interval=None,
+        number_per_segment=None,
+        total_number=None,
+        **kwargs,
+    ):
         """Seed elements repeatedly in time along a segment.
 
         The segment goes from lon[0],lat[0] to lon[1],lat[1].
@@ -1284,20 +1298,18 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         """
 
-        numtimes = int((end_time - start_time).total_seconds() /
-                       time_interval.total_seconds() + 1)
+        numtimes = int(
+            (end_time - start_time).total_seconds() / time_interval.total_seconds() + 1
+        )
         times = [start_time + i * time_interval for i in range(numtimes)]
 
-        geod = pyproj.Geod(ellps='WGS84')
+        geod = pyproj.Geod(ellps="WGS84")
         if number_per_segment is None:
             number_per_segment = int(np.floor(total_number / numtimes))
 
-        s_lonlats = geod.npts(lons[0],
-                              lats[0],
-                              lons[1],
-                              lats[1],
-                              number_per_segment,
-                              radians=False)
+        s_lonlats = geod.npts(
+            lons[0], lats[0], lons[1], lats[1], number_per_segment, radians=False
+        )
         slon, slat = list(zip(*s_lonlats))
         slon = np.atleast_1d(slon)
         slat = np.atleast_1d(slat)
@@ -1310,8 +1322,10 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         if total_number is not None:
             additional_elements = total_number - len(lon.ravel())
-            print('Repeating the %d last points, to obtain %d elements' %
-                  (additional_elements, total_number))
+            print(
+                "Repeating the %d last points, to obtain %d elements"
+                % (additional_elements, total_number)
+            )
             lon = np.concatenate((lon, lon[-additional_elements::]))
             lat = np.concatenate((lat, lat[-additional_elements::]))
             time = np.concatenate((time, time[-additional_elements::]))
@@ -1339,22 +1353,27 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             return
 
         if number is None:
-            number = self.get_config('seed:number')
+            number = self.get_config("seed:number")
 
         lons = np.asarray(lons)
         lats = np.asarray(lats)
         if len(lons) < 3:
-            logger.info('At least three points needed to make a polygon')
+            logger.info("At least three points needed to make a polygon")
             return
         if len(lons) != len(lats):
-            raise ValueError('lon and lat arrays must have same length.')
+            raise ValueError("lon and lat arrays must have same length.")
         poly = Polygon(list(zip(lons, lats)), closed=True)
         # Place N points within the polygons
-        proj = pyproj.Proj('+proj=aea +lat_1=%f +lat_2=%f +lat_0=%f '
-                           '+lon_0=%f +R=6370997.0 +units=m +ellps=WGS84' %
-                           (lats.min(), lats.max(),
-                            (lats.min() + lats.max()) / 2,
-                            (lons.min() + lons.max()) / 2))
+        proj = pyproj.Proj(
+            "+proj=aea +lat_1=%f +lat_2=%f +lat_0=%f "
+            "+lon_0=%f +R=6370997.0 +units=m +ellps=WGS84"
+            % (
+                lats.min(),
+                lats.max(),
+                (lats.min() + lats.max()) / 2,
+                (lons.min() + lons.max()) / 2,
+            )
+        )
         lonlat = poly.get_xy()
         lon = lonlat[:, 0]
         lat = lonlat[:, 1]
@@ -1372,12 +1391,16 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         lon = lonlat[:, 0]
         lat = lonlat[:, 1]
         x, y = proj(lon, lat)
-        xvec = np.linspace(x.min() + deltax / 2,
-                           x.max() - deltax / 2,
-                           int((x.max() - x.min()) / deltax))
-        yvec = np.linspace(y.min() + deltax / 2,
-                           y.max() - deltax / 2,
-                           int((y.max() - y.min()) / deltax))
+        xvec = np.linspace(
+            x.min() + deltax / 2,
+            x.max() - deltax / 2,
+            int((x.max() - x.min()) / deltax),
+        )
+        yvec = np.linspace(
+            y.min() + deltax / 2,
+            y.max() - deltax / 2,
+            int((y.max() - y.min()) / deltax),
+        )
         x, y = np.meshgrid(xvec, yvec)
         lon, lat = proj(x, y, inverse=True)
         lon = lon.ravel()
@@ -1391,7 +1414,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             lonpoints = np.append(lonpoints, lon[ind])
             latpoints = np.append(latpoints, lat[ind])
         if len(ind) == 0:
-            logger.info('Small or irregular polygon, using center point.')
+            logger.info("Small or irregular polygon, using center point.")
             lonpoints = np.atleast_1d(np.mean(lons))
             latpoints = np.atleast_1d(np.mean(lats))
         # Truncate if too many
@@ -1419,10 +1442,10 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             from osgeo import ogr, osr
         except Exception as e:
             logger.warning(e)
-            raise ValueError('OGR library is needed to parse WKT')
+            raise ValueError("OGR library is needed to parse WKT")
 
         if number is None:
-            number = self.get_config('seed:number')
+            number = self.get_config("seed:number")
 
         geom = ogr.CreateGeometryFromWkt(wkt)
         total_area = 0
@@ -1430,7 +1453,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             g = geom.GetGeometryRef(i)
             total_area += g.GetArea()
 
-        logger.info('Total area of all polygons: %s m2' % total_area)
+        logger.info("Total area of all polygons: %s m2" % total_area)
         num_seeded = 0
         for i in range(0, geom.GetGeometryCount()):
             g = geom.GetGeometryRef(i)
@@ -1439,8 +1462,10 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 # For the last feature we seed the remaining number,
                 # avoiding difference due to rounding:
                 num_elements = number - num_seeded
-            logger.info('\tSeeding %s elements within polygon number %s' %
-                        (num_elements, str(i)))
+            logger.info(
+                "\tSeeding %s elements within polygon number %s"
+                % (num_elements, str(i))
+            )
             try:
                 g.Transform(coordTrans)
             except:
@@ -1456,33 +1481,30 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 lons = [r.GetX(j) for j in range(r.GetPointCount())]
                 lats = [r.GetY(j) for j in range(r.GetPointCount())]
 
-            self.seed_within_polygon(lons=lons,
-                                     lats=lats,
-                                     number=num_elements,
-                                     **kwargs)
+            self.seed_within_polygon(
+                lons=lons, lats=lats, number=num_elements, **kwargs
+            )
             num_seeded += num_elements
 
     @require_mode(mode=Mode.Ready)
-    def seed_from_shapefile(self,
-                            shapefile,
-                            number,
-                            layername=None,
-                            featurenum=None,
-                            **kwargs):
+    def seed_from_shapefile(
+        self, shapefile, number, layername=None, featurenum=None, **kwargs
+    ):
         """Seeds elements within contours read from a shapefile"""
 
         try:
             from osgeo import ogr, osr
         except Exception as e:
             logger.warning(e)
-            raise ValueError('OGR library is needed to read shapefiles.')
+            raise ValueError("OGR library is needed to read shapefiles.")
 
-        if 'timeformat' in kwargs:
+        if "timeformat" in kwargs:
             # Recondstructing time from filename, where 'timeformat'
             # is forwarded to datetime.strptime()
-            kwargs['time'] = datetime.strptime(os.path.basename(shapefile),
-                                               kwargs['timeformat'])
-            del kwargs['timeformat']
+            kwargs["time"] = datetime.strptime(
+                os.path.basename(shapefile), kwargs["timeformat"]
+            )
+            del kwargs["timeformat"]
 
         num_seeded_before = self.num_elements_scheduled()
 
@@ -1495,29 +1517,30 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         for layer in s:
             if layername is not None and layer.GetName() != layername:
-                logger.info('Skipping layer: ' + layer.GetName())
+                logger.info("Skipping layer: " + layer.GetName())
                 continue
             else:
-                logger.info('Seeding for layer: %s (%s features)' %
-                            (layer.GetDescription(), layer.GetFeatureCount()))
+                logger.info(
+                    "Seeding for layer: %s (%s features)"
+                    % (layer.GetDescription(), layer.GetFeatureCount())
+                )
 
-            coordTrans = osr.CoordinateTransformation(layer.GetSpatialRef(),
-                                                      targetSRS)
+            coordTrans = osr.CoordinateTransformation(layer.GetSpatialRef(), targetSRS)
 
             if featurenum is None:
                 featurenum = range(1, layer.GetFeatureCount() + 1)
             else:
                 featurenum = np.atleast_1d(featurenum)
             if max(featurenum) > layer.GetFeatureCount():
-                raise ValueError('Only %s features in layer.' %
-                                 layer.GetFeatureCount())
+                raise ValueError("Only %s features in layer." % layer.GetFeatureCount())
 
             # Loop first through all features to determine total area
             layer.ResetReading()
             area_srs = osr.SpatialReference()
             area_srs.ImportFromEPSG(3857)
             areaTransform = osr.CoordinateTransformation(
-                layer.GetSpatialRef(), area_srs)
+                layer.GetSpatialRef(), area_srs
+            )
 
             areas = np.zeros(len(featurenum))
             for i, f in enumerate(featurenum):
@@ -1529,7 +1552,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
             total_area = np.sum(areas)
             layer.ResetReading()  # Rewind to first layer
-            logger.info('Total area of all polygons: %s m2' % total_area)
+            logger.info("Total area of all polygons: %s m2" % total_area)
             # Find number of points per polygon
             numbers = np.round(number * areas / total_area).astype(int)
             numbers[numbers.argmax()] += int(number - sum(numbers))
@@ -1540,161 +1563,171 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                     continue
                 num_elements = numbers[i]
                 geom = feature.GetGeometryRef()
-                logger.info('\tSeeding %s elements within polygon number %s' %
-                            (num_elements, featurenum[i]))
+                logger.info(
+                    "\tSeeding %s elements within polygon number %s"
+                    % (num_elements, featurenum[i])
+                )
                 try:
                     geom.Transform(coordTrans)
                 except Exception as e:
-                    logger.warning('Could not transform coordinates:')
+                    logger.warning("Could not transform coordinates:")
                     logger.warning(e)
                     pass
-                #b = geom.GetBoundary()
-                #if b is not None:
+                # b = geom.GetBoundary()
+                # if b is not None:
                 #    points = b.GetPoints()
                 #    lons = [p[0] for p in points]
                 #    lats = [p[1] for p in points]
-                #else:
+                # else:
                 # Alternative if OGR is not built with GEOS support
                 r = geom.GetGeometryRef(0)
                 lons = [r.GetY(j) for j in range(r.GetPointCount())]
                 lats = [r.GetX(j) for j in range(r.GetPointCount())]
 
-                self.seed_within_polygon(lons=lons,
-                                         lats=lats,
-                                         number=num_elements,
-                                         **kwargs)
+                self.seed_within_polygon(
+                    lons=lons, lats=lats, number=num_elements, **kwargs
+                )
 
     @require_mode(mode=Mode.Ready)
     def seed_letters(self, text, lon, lat, time, number, scale=1.2):
         """Seed elements within text polygons"""
         from matplotlib.font_manager import FontProperties
-        fp = FontProperties(family='Bitstream Vera Sans', weight='bold')
-        pol = matplotlib.textpath.TextPath((lon, lat),
-                                           text,
-                                           size=1 * scale,
-                                           prop=fp)
-        patch = matplotlib.patches.PathPatch(pol,
-                                             facecolor='none',
-                                             edgecolor='black',
-                                             transform=ccrs.PlateCarree())
+
+        fp = FontProperties(family="Bitstream Vera Sans", weight="bold")
+        pol = matplotlib.textpath.TextPath((lon, lat), text, size=1 * scale, prop=fp)
+        patch = matplotlib.patches.PathPatch(
+            pol, facecolor="none", edgecolor="black", transform=ccrs.PlateCarree()
+        )
         po = patch.get_path().to_polygons()
         for p in po:
-            self.seed_within_polygon(lons=p[:, 0],
-                                     lats=p[:, 1],
-                                     number=number,
-                                     time=time)
+            self.seed_within_polygon(
+                lons=p[:, 0], lats=p[:, 1], number=number, time=time
+            )
 
     @require_mode(mode=Mode.Ready)
     def seed_from_ladim(self, ladimfile, roms):
         """Seed elements from ladim \\*.rls text file: [time, x, y, z, name]"""
 
-        data = np.loadtxt(ladimfile,
-                          dtype={
-                              'names': ('time', 'x', 'y', 'z'),
-                              'formats': ('S20', 'f4', 'f4', 'f4')
-                          },
-                          usecols=(0, 1, 2, 3))
+        data = np.loadtxt(
+            ladimfile,
+            dtype={
+                "names": ("time", "x", "y", "z"),
+                "formats": ("S20", "f4", "f4", "f4"),
+            },
+            usecols=(0, 1, 2, 3),
+        )
 
-        time = [datetime.strptime(t, "%Y-%m-%dT%H") for t in data['time']]
+        time = [datetime.strptime(t, "%Y-%m-%dT%H") for t in data["time"]]
         time = np.array(time)
 
-        lon, lat = roms.xy2lonlat(data['x'], data['y'])
-        z = -data['z']
+        lon, lat = roms.xy2lonlat(data["x"], data["y"])
+        z = -data["z"]
 
-        logger.info('Seeding %i elements from %s:' % (len(lon), ladimfile))
-        logger.info('    Lons: %f to %f' % (lon.min(), lon.max()))
-        logger.info('    Lats: %f to %f' % (lat.min(), lat.max()))
-        logger.info('    Depths: %f to %f' % (z.min(), z.max()))
-        logger.info('    Time: %s to %s' % (time.min(), time.max()))
+        logger.info("Seeding %i elements from %s:" % (len(lon), ladimfile))
+        logger.info("    Lons: %f to %f" % (lon.min(), lon.max()))
+        logger.info("    Lats: %f to %f" % (lat.min(), lat.max()))
+        logger.info("    Depths: %f to %f" % (z.min(), z.max()))
+        logger.info("    Time: %s to %s" % (time.min(), time.max()))
         elements = self.ElementType(lon=lon, lat=lat, z=-z)
 
         self.schedule_elements(elements, time)
 
     def horizontal_diffusion(self):
         """Move elements with random walk according to given horizontal diffuivity."""
-        D = self.get_config('drift:horizontal_diffusivity')
+        D = self.get_config("drift:horizontal_diffusivity")
         if D == 0:
-            logger.debug('Horizontal diffusivity is 0, no random walk.')
+            logger.debug("Horizontal diffusivity is 0, no random walk.")
             return
         if self.num_elements_active() == 0:
-            logger.debug('No active elements, skipping horizontal diffusivity.')
+            logger.debug("No active elements, skipping horizontal diffusivity.")
             return
         dt = np.abs(self.time_step.total_seconds())
-        x_vel = self.elements.moving * np.sqrt(2 * D / dt) * np.random.normal(
-            scale=1, size=self.num_elements_active())
-        y_vel = self.elements.moving * np.sqrt(2 * D / dt) * np.random.normal(
-            scale=1, size=self.num_elements_active())
+        x_vel = (
+            self.elements.moving
+            * np.sqrt(2 * D / dt)
+            * np.random.normal(scale=1, size=self.num_elements_active())
+        )
+        y_vel = (
+            self.elements.moving
+            * np.sqrt(2 * D / dt)
+            * np.random.normal(scale=1, size=self.num_elements_active())
+        )
         speed = np.sqrt(x_vel * x_vel + y_vel * y_vel)
         logger.debug(
-            'Moving elements according to horizontal diffusivity of %s, with speeds between %s and %s m/s'
-            % (D, speed.min(), speed.max()))
+            "Moving elements according to horizontal diffusivity of %s, with speeds between %s and %s m/s"
+            % (D, speed.min(), speed.max())
+        )
         self.update_positions(x_vel, y_vel)
 
-    def deactivate_elements(self, indices, reason='deactivated'):
+    def deactivate_elements(self, indices, reason="deactivated"):
         """Schedule deactivated particles for deletion (at end of step)"""
         if any(indices) is False:
             return
         if reason not in self.status_categories:
             self.status_categories.append(reason)
-            logger.debug('Added status %s' % (reason))
+            logger.debug("Added status %s" % (reason))
         reason_number = self.status_categories.index(reason)
-        #if not hasattr(self.elements.status, "__len__"):
+        # if not hasattr(self.elements.status, "__len__"):
         if len(np.atleast_1d(self.elements.status)) == 1:
             status = self.elements.status.item()
             self.elements.status = np.zeros(self.num_elements_active())
             self.elements.status.fill(status)
         # Deactivate elements, if they have not already been deactivated
-        self.elements.status[indices & (self.elements.status ==0)] = \
-            reason_number
+        self.elements.status[indices & (self.elements.status == 0)] = reason_number
         self.elements.moving[indices] = 0
-        logger.debug('%s elements scheduled for deactivation (%s)' %
-                     (np.sum(indices), reason))
         logger.debug(
-            '\t(z: %f to %f)' %
-            (self.elements.z[indices].min(), self.elements.z[indices].max()))
+            "%s elements scheduled for deactivation (%s)" % (np.sum(indices), reason)
+        )
+        logger.debug(
+            "\t(z: %f to %f)"
+            % (self.elements.z[indices].min(), self.elements.z[indices].max())
+        )
 
     def remove_deactivated_elements(self):
         """Moving deactivated elements from self.elements
         to self.elements_deactivated."""
 
         # All particles scheduled for deletion
-        indices = (self.elements.status != 0)
-        #try:
+        indices = self.elements.status != 0
+        # try:
         #    len(indices)
-        #except:
+        # except:
         if len(indices) == 0 or np.sum(indices) == 0:
-            logger.debug('No elements to deactivate')
+            logger.debug("No elements to deactivate")
             return  # No elements scheduled for deactivation
         # Basic, but some more housekeeping will be required later
         self.elements.move_elements(self.elements_deactivated, indices)
-        logger.debug('Removed %i elements.' % (np.sum(indices)))
-        if hasattr(self, 'environment'):
+        logger.debug("Removed %i elements." % (np.sum(indices)))
+        if hasattr(self, "environment"):
             self.environment = self.environment[~indices]
-            logger.debug('Removed %i values from environment.' %
-                         (np.sum(indices)))
-        if hasattr(self, 'environment_profiles') and \
-                self.environment_profiles is not None:
+            logger.debug("Removed %i values from environment." % (np.sum(indices)))
+        if (
+            hasattr(self, "environment_profiles")
+            and self.environment_profiles is not None
+        ):
             for varname, profiles in self.environment_profiles.items():
-                logger.debug('remove items from profile for ' + varname)
-                if varname != 'z':
-                    self.environment_profiles[varname] = \
-                        profiles[:, ~indices]
-            logger.debug('Removed %i values from environment_profiles.' %
-                         (np.sum(indices)))
-            #if self.num_elements_active() == 0:
+                logger.debug("remove items from profile for " + varname)
+                if varname != "z":
+                    self.environment_profiles[varname] = profiles[:, ~indices]
+            logger.debug(
+                "Removed %i values from environment_profiles." % (np.sum(indices))
+            )
+            # if self.num_elements_active() == 0:
             #    raise ValueError('No more active elements.')  # End simulation
 
     @require_mode(mode=Mode.Run, post_next_mode=True)
-    def run(self,
-            time_step=None,
-            steps=None,
-            time_step_output=None,
-            duration=None,
-            end_time=None,
-            outfile=None,
-            export_variables=None,
-            export_buffer_length=100,
-            stop_on_error=False):
+    def run(
+        self,
+        time_step=None,
+        steps=None,
+        time_step_output=None,
+        duration=None,
+        end_time=None,
+        outfile=None,
+        export_variables=None,
+        export_buffer_length=100,
+        stop_on_error=False,
+    ):
         """Start a trajectory simulation, after initial configuration.
 
         Performs the main loop:
@@ -1733,20 +1766,20 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         # Exporting software and hardware specification, for possible debugging
         logger.debug(opendrift.versions())
 
-        self.timer_end('configuration')
-        self.timer_start('preparing main loop')
+        self.timer_end("configuration")
+        self.timer_start("preparing main loop")
 
         if self.num_elements_scheduled() == 0:
-            raise ValueError('Please seed elements before starting a run.')
+            raise ValueError("Please seed elements before starting a run.")
         self.elements = self.ElementType()
 
         # Export seed_geojson as FeatureCollection string
-        self.add_metadata('seed_geojson',
-                          geojson.FeatureCollection(self.seed_geojson))
+        self.add_metadata("seed_geojson", geojson.FeatureCollection(self.seed_geojson))
 
         if outfile is None and export_buffer_length is not None:
-            logger.debug('No output file is specified, '
-                         'neglecting export_buffer_length')
+            logger.debug(
+                "No output file is specified, " "neglecting export_buffer_length"
+            )
             export_buffer_length = None
 
         # Some cleanup needed if starting from imported state
@@ -1764,15 +1797,13 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         # Simulation time step
         ########################
         if time_step is None:
-            time_step = timedelta(
-                minutes=self.get_config('general:time_step_minutes'))
+            time_step = timedelta(minutes=self.get_config("general:time_step_minutes"))
         if type(time_step) is not timedelta:
             # Time step may be given in seconds, as alternative to timedelta
             time_step = timedelta(seconds=time_step)
         self.time_step = time_step
         if time_step_output is None:
-            time_step_output = self.get_config(
-                'general:time_step_output_minutes')
+            time_step_output = self.get_config("general:time_step_output_minutes")
             if time_step_output is None:
                 self.time_step_output = self.time_step
             else:
@@ -1785,27 +1816,34 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             if self.time_step_output.days >= 0 and self.time_step.days < 0:
                 self.time_step_output = -self.time_step_output
 
-        time_step_ratio = self.time_step_output.total_seconds() / \
-            self.time_step.total_seconds()
+        time_step_ratio = (
+            self.time_step_output.total_seconds() / self.time_step.total_seconds()
+        )
         if time_step_ratio < 1:
-            raise ValueError('Output time step must be equal or larger '
-                             'than calculation time step.')
+            raise ValueError(
+                "Output time step must be equal or larger "
+                "than calculation time step."
+            )
         if not time_step_ratio.is_integer():
-            raise ValueError('Ratio of calculation and output time steps '
-                             'must be an integer - given ratio is %s' %
-                             time_step_ratio)
+            raise ValueError(
+                "Ratio of calculation and output time steps "
+                "must be an integer - given ratio is %s" % time_step_ratio
+            )
         ########################
         # Simulation duration
         ########################
         if time_step.days < 0:
-            logger.info(
-                'Backwards simulation, starting from last seeded element')
+            logger.info("Backwards simulation, starting from last seeded element")
             self.start_time = self.elements_scheduled_time.max()
-        if (duration is not None and end_time is not None) or \
-            (duration is not None and steps is not None) or \
-                (steps is not None and end_time is not None):
-            raise ValueError('Only one of "steps", "duration" and "end_time" '
-                             'may be provided simultaneously')
+        if (
+            (duration is not None and end_time is not None)
+            or (duration is not None and steps is not None)
+            or (steps is not None and end_time is not None)
+        ):
+            raise ValueError(
+                'Only one of "steps", "duration" and "end_time" '
+                "may be provided simultaneously"
+            )
         if duration is None and end_time is None:
             if steps is not None:
                 duration = steps * self.time_step
@@ -1816,9 +1854,10 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                             end_time = reader.end_time
                         else:
                             end_time = min(end_time, reader.end_time)
-                    logger.info('Duration, steps or end time not specified, '
-                                'running until end of first reader: %s' %
-                                (end_time))
+                    logger.info(
+                        "Duration, steps or end time not specified, "
+                        "running until end of first reader: %s" % (end_time)
+                    )
         if duration is None:
             duration = end_time - self.start_time
 
@@ -1826,46 +1865,46 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             # Duration shall also be negative for backwards run
             duration = -duration
 
-        if np.sign(duration.total_seconds()) * np.sign(
-                time_step.total_seconds()) < 0:
-            raise ValueError(
-                "Time step must be negative if duration is negative.")
+        if np.sign(duration.total_seconds()) * np.sign(time_step.total_seconds()) < 0:
+            raise ValueError("Time step must be negative if duration is negative.")
 
-        self.expected_steps_output = duration.total_seconds() / \
-            self.time_step_output.total_seconds() + 1  # Includes start and end
-        self.expected_steps_calculation = duration.total_seconds() / \
-            self.time_step.total_seconds()
+        self.expected_steps_output = (
+            duration.total_seconds() / self.time_step_output.total_seconds() + 1
+        )  # Includes start and end
+        self.expected_steps_calculation = (
+            duration.total_seconds() / self.time_step.total_seconds()
+        )
         self.expected_steps_output = int(self.expected_steps_output)
         self.expected_steps_calculation = int(self.expected_steps_calculation)
-        self.expected_end_time = self.start_time + self.expected_steps_calculation * self.time_step
+        self.expected_end_time = (
+            self.start_time + self.expected_steps_calculation * self.time_step
+        )
 
         ##############################################################
         # Prepare readers for the requested simulation domain/time
         ##############################################################
-        max_distance = \
-                self.get_config('drift:max_speed')*self.expected_steps_calculation * \
-            np.abs(self.time_step.total_seconds())
-        deltalat = max_distance / 111000.
-        deltalon = deltalat / np.cos(
-            np.radians(np.mean(self.elements_scheduled.lat)))
+        max_distance = (
+            self.get_config("drift:max_speed")
+            * self.expected_steps_calculation
+            * np.abs(self.time_step.total_seconds())
+        )
+        deltalat = max_distance / 111000.0
+        deltalon = deltalat / np.cos(np.radians(np.mean(self.elements_scheduled.lat)))
         # TODO: extent should ideally be a general polygon, not only lon/lat-min/max
         # TODO: Should also take into account eventual lifetime of elements
         simulation_extent = [
-            np.maximum(-360,
-                       self.elements_scheduled.lon.min() - deltalon),
-            np.maximum(-89,
-                       self.elements_scheduled.lat.min() - deltalat),
-            np.minimum(360,
-                       self.elements_scheduled.lon.max() + deltalon),
-            np.minimum(89,
-                       self.elements_scheduled.lat.max() + deltalat)
+            np.maximum(-360, self.elements_scheduled.lon.min() - deltalon),
+            np.maximum(-89, self.elements_scheduled.lat.min() - deltalat),
+            np.minimum(360, self.elements_scheduled.lon.max() + deltalon),
+            np.minimum(89, self.elements_scheduled.lat.max() + deltalat),
         ]
         if simulation_extent[2] == 360 and simulation_extent[0] < 0:
             simulation_extent[0] = 0
 
         logger.debug(
-            'Finalizing environment and preparing readers for simulation coverage (%s) and time (%s to %s)'
-            % (simulation_extent, self.start_time, self.expected_end_time))
+            "Finalizing environment and preparing readers for simulation coverage (%s) and time (%s to %s)"
+            % (simulation_extent, self.start_time, self.expected_end_time)
+        )
 
         # Store expected simulation extent, to check if new readers have coverage
         self.simulation_extent = simulation_extent
@@ -1881,12 +1920,12 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         if self.time_step.days < 0:
             # For backwards simulation, we start at last seeded element
-            logger.info('Backwards simulation, starting at '
-                        'time of last seeded element')
+            logger.info(
+                "Backwards simulation, starting at " "time of last seeded element"
+            )
             self.time = self.elements_scheduled_time.max()
             # Flipping ID array, so that lowest IDs are released first
-            self.elements_scheduled.ID = \
-                np.flipud(self.elements_scheduled.ID)
+            self.elements_scheduled.ID = np.flipud(self.elements_scheduled.ID)
         else:
             # Forward simulation, start time has been set when seeding
             self.time = self.start_time
@@ -1894,33 +1933,35 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         # Add the output variables which are always required
         if export_variables is not None:
             export_variables = list(
-                set(export_variables + ['lon', 'lat', 'ID', 'status']))
+                set(export_variables + ["lon", "lat", "ID", "status"])
+            )
         self.export_variables = export_variables
         # Initialise array to hold history (element properties and environment)
         # for export to file.
-        history_dtype_fields = [(name,
-                                 self.ElementType.variables[name]['dtype'])
-                                for name in self.ElementType.variables]
+        history_dtype_fields = [
+            (name, self.ElementType.variables[name]["dtype"])
+            for name in self.ElementType.variables
+        ]
         # Add environment variables
         self.history_metadata = self.ElementType.variables.copy()
         for env_var in self.required_variables:
-            history_dtype_fields.append((env_var, np.dtype('float32')))
+            history_dtype_fields.append((env_var, np.dtype("float32")))
             self.history_metadata[env_var] = {}
 
         # Remove variables from output array, if only subset is requested
         if self.export_variables is not None:
             history_dtype_fields = [
-                f for f in history_dtype_fields
-                if f[0] in self.export_variables
+                f for f in history_dtype_fields if f[0] in self.export_variables
             ]
             for m in list(self.history_metadata):
                 if m not in self.export_variables:
                     del self.history_metadata[m]
 
         history_dtype = np.dtype(history_dtype_fields)
-        self.history = np.ma.array(np.zeros(
-            (len(self.elements_scheduled), self.export_buffer_length)),
-                                   dtype=history_dtype)
+        self.history = np.ma.array(
+            np.zeros((len(self.elements_scheduled), self.export_buffer_length)),
+            dtype=history_dtype,
+        )
         self.history.mask = True
         self.steps_exported = 0
 
@@ -1930,23 +1971,26 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             self.outfile = None
 
         # Move point seeded on land to ocean
-        if self.get_config('seed:ocean_only') is True and \
-            ('land_binary_mask' in self.required_variables):
-            #('land_binary_mask' not in self.fallback_values) and \
-            self.timer_start('preparing main loop:moving elements to ocean')
-            self.elements_scheduled.lon, self.elements_scheduled.lat = \
-                self.closest_ocean_points(self.elements_scheduled.lon,
-                                          self.elements_scheduled.lat)
-            self.timer_end('preparing main loop:moving elements to ocean')
+        if self.get_config("seed:ocean_only") is True and (
+            "land_binary_mask" in self.required_variables
+        ):
+            # ('land_binary_mask' not in self.fallback_values) and \
+            self.timer_start("preparing main loop:moving elements to ocean")
+            self.elements_scheduled.lon, self.elements_scheduled.lat = (
+                self.closest_ocean_points(
+                    self.elements_scheduled.lon, self.elements_scheduled.lat
+                )
+            )
+            self.timer_end("preparing main loop:moving elements to ocean")
 
         #############################
         # Check validity domain
         #############################
         validity_domain = [
-            self.get_config('drift:deactivate_west_of'),
-            self.get_config('drift:deactivate_east_of'),
-            self.get_config('drift:deactivate_south_of'),
-            self.get_config('drift:deactivate_north_of')
+            self.get_config("drift:deactivate_west_of"),
+            self.get_config("drift:deactivate_east_of"),
+            self.get_config("drift:deactivate_south_of"),
+            self.get_config("drift:deactivate_north_of"),
         ]
         if validity_domain == [None, None, None, None]:
             self.validity_domain = None
@@ -1961,22 +2005,30 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         ##########################
         # Main loop
         ##########################
-        self.add_metadata('simulation_time', datetime.now())
-        self.timer_end('preparing main loop')
-        self.timer_start('main loop')
+        self.add_metadata("simulation_time", datetime.now())
+        self.timer_end("preparing main loop")
+        self.timer_start("main loop")
         for i in range(self.expected_steps_calculation):
             try:
                 # Release elements
                 self.release_elements()
 
-                if self.num_elements_active(
-                ) == 0 and self.num_elements_scheduled() > 0:
-                    self.steps_calculation += 1
+                if (
+                    self.num_elements_active() == 0
+                    and self.num_elements_scheduled() > 0
+                ):
+
                     logger.info(
-                        'No active but %s scheduled elements, skipping timestep %s (%s)'
-                        % (self.num_elements_scheduled(),
-                           self.steps_calculation, self.time))
+                        "No active but %s scheduled elements, skipping timestep %s (%s)"
+                        % (
+                            self.num_elements_scheduled(),
+                            self.steps_calculation
+                            + 1,  # LH correction : +1 to be consistent with the line 2048
+                            self.time,
+                        )
+                    )
                     self.state_to_buffer()  # Append status to history array
+                    self.steps_calculation += 1  # LH correction : Move from line 2020 to 2030 to propagate the step calculation after the state_to_buffer and to be consistent with the line 2106
                     if self.time is not None:
                         self.time = self.time + self.time_step
                     continue
@@ -1988,16 +2040,20 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 if self.show_continuous_performance is True:
                     logger.info(self.performance())
                 # Display time to terminal
-                logger.debug('===================================' * 2)
-                logger.info('%s - step %i of %i - %i active elements '
-                            '(%i deactivated)' %
-                            (self.time, self.steps_calculation + 1,
-                             self.expected_steps_calculation,
-                             self.num_elements_active(),
-                             self.num_elements_deactivated()))
-                logger.debug('%s elements scheduled.' %
-                             self.num_elements_scheduled())
-                logger.debug('===================================' * 2)
+                logger.debug("===================================" * 2)
+                logger.info(
+                    "%s - step %i of %i - %i active elements "
+                    "(%i deactivated)"
+                    % (
+                        self.time,
+                        self.steps_calculation + 1,
+                        self.expected_steps_calculation,
+                        self.num_elements_active(),
+                        self.num_elements_deactivated(),
+                    )
+                )
+                logger.debug("%s elements scheduled." % self.num_elements_scheduled())
+                logger.debug("===================================" * 2)
                 if len(self.elements.lon) > 0:
                     lonmin = self.elements.lon.min()
                     lonmax = self.elements.lon.max()
@@ -2006,28 +2062,29 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                     zmin = self.elements.z.min()
                     zmax = self.elements.z.max()
                     if latmin == latmax:
-                        logger.debug('\t\tlatitude =  %s' % (latmin))
+                        logger.debug("\t\tlatitude =  %s" % (latmin))
                     else:
-                        logger.debug('\t\t%s <- latitude  -> %s' %
-                                     (latmin, latmax))
+                        logger.debug("\t\t%s <- latitude  -> %s" % (latmin, latmax))
                     if lonmin == lonmax:
-                        logger.debug('\t\tlongitude = %s' % (lonmin))
+                        logger.debug("\t\tlongitude = %s" % (lonmin))
                     else:
-                        logger.debug('\t\t%s <- longitude -> %s' %
-                                     (lonmin, lonmax))
+                        logger.debug("\t\t%s <- longitude -> %s" % (lonmin, lonmax))
                     if zmin == zmax:
-                        logger.debug('\t\tz = %s' % (zmin))
+                        logger.debug("\t\tz = %s" % (zmin))
                     else:
-                        logger.debug('\t\t%s   <- z ->   %s' % (zmin, zmax))
-                    logger.debug('---------------------------------')
+                        logger.debug("\t\t%s   <- z ->   %s" % (zmin, zmax))
+                    logger.debug("---------------------------------")
 
-                self.environment, self.environment_profiles, missing = \
-                    self.env.get_environment(list(self.required_variables),
-                                         self.time,
-                                         self.elements.lon,
-                                         self.elements.lat,
-                                         self.elements.z,
-                                         self.required_profiles)
+                self.environment, self.environment_profiles, missing = (
+                    self.env.get_environment(
+                        list(self.required_variables),
+                        self.time,
+                        self.elements.lon,
+                        self.elements.lat,
+                        self.elements.z,
+                        self.required_profiles,
+                    )
+                )
 
                 self.store_previous_variables()
 
@@ -2040,7 +2097,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
                 self.interact_with_seafloor()
 
-                self.deactivate_elements(missing, reason='missing_data')
+                self.deactivate_elements(missing, reason="missing_data")
 
                 self.state_to_buffer()  # Append status to history array
 
@@ -2049,61 +2106,69 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 # Propagate one timestep forwards
                 self.steps_calculation += 1
 
-                if self.num_elements_active(
-                ) == 0 and self.num_elements_scheduled() == 0:
-                    raise ValueError(
-                        'No more active or scheduled elements, quitting.')
+                if (
+                    self.num_elements_active() == 0
+                    and self.num_elements_scheduled() == 0
+                ):
+                    raise ValueError("No more active or scheduled elements, quitting.")
 
                 # Store location, in case elements shall be moved back
                 self.store_present_positions()
 
                 #####################################################
                 if self.num_elements_active() > 0:
-                    logger.debug('Calling %s.update()' % type(self).__name__)
-                    self.timer_start('main loop:updating elements')
+                    logger.debug("Calling %s.update()" % type(self).__name__)
+                    self.timer_start("main loop:updating elements")
                     self.update()
-                    self.timer_end('main loop:updating elements')
+                    self.timer_end("main loop:updating elements")
                 else:
-                    logger.info('No active elements, skipping update() method')
+                    logger.info("No active elements, skipping update() method")
                 #####################################################
 
                 self.horizontal_diffusion()
 
-                if self.num_elements_active(
-                ) == 0 and self.num_elements_scheduled() == 0:
+                if (
+                    self.num_elements_active() == 0
+                    and self.num_elements_scheduled() == 0
+                ):
                     raise ValueError(
-                        'No active or scheduled elements, quitting simulation')
+                        "No active or scheduled elements, quitting simulation"
+                    )
 
-                logger.debug('%s active elements (%s deactivated)' %
-                             (self.num_elements_active(),
-                              self.num_elements_deactivated()))
+                logger.debug(
+                    "%s active elements (%s deactivated)"
+                    % (self.num_elements_active(), self.num_elements_deactivated())
+                )
                 # Updating time
                 if self.time is not None:
                     self.time = self.time + self.time_step
 
             except Exception as e:
-                message = ('The simulation stopped before requested '
-                           'end time was reached.')
+                message = (
+                    "The simulation stopped before requested " "end time was reached."
+                )
                 logger.warning(message)
                 self.store_message(message)
-                logger.info('========================')
-                logger.info('End of simulation:')
+                logger.info("========================")
+                logger.info("End of simulation:")
                 logger.info(e)
                 logger.info(traceback.format_exc())
                 logger.info(self.get_messages())
-                if not hasattr(self, 'environment'):
-                    sys.exit('Simulation aborted. ' + self.get_messages())
-                logger.info('========================')
+                if not hasattr(self, "environment"):
+                    sys.exit("Simulation aborted. " + self.get_messages())
+                logger.info("========================")
                 if stop_on_error is True:
-                    sys.exit('Stopping on error. ' + self.get_messages())
+                    sys.exit("Stopping on error. " + self.get_messages())
                 if self.steps_calculation <= 1:
-                    raise ValueError('Simulation stopped within '
-                                     'first timestep. ' + self.get_messages())
+                    raise ValueError(
+                        "Simulation stopped within "
+                        "first timestep. " + self.get_messages()
+                    )
                 break
 
-        self.timer_end('main loop')
-        self.timer_start('cleaning up')
-        logger.debug('Cleaning up')
+        self.timer_end("main loop")
+        self.timer_start("cleaning up")
+        logger.debug("Cleaning up")
 
         self.interact_with_coastline(final=True)
         self.state_to_buffer()  # Append final status to buffer
@@ -2112,28 +2177,30 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         # Add some metadata
         #############################
         for var in self.required_variables:
-            keyword = 'reader_' + var
+            keyword = "reader_" + var
             if var not in self.env.priority_list:
-                fallback = self.get_config(f'environment:fallback:{var}')
+                fallback = self.get_config(f"environment:fallback:{var}")
                 if fallback is not None:
                     self.add_metadata(keyword, fallback)
                 else:
                     self.add_metadata(keyword, None)
             else:
                 readers = self.env.priority_list[var]
-                if readers[0].startswith(
-                        'constant_reader') and var in self.env.readers[
-                            readers[0]]._parameter_value_map:
+                if (
+                    readers[0].startswith("constant_reader")
+                    and var in self.env.readers[readers[0]]._parameter_value_map
+                ):
                     self.add_metadata(
-                        keyword, self.env.readers[
-                            readers[0]]._parameter_value_map[var][0])
+                        keyword,
+                        self.env.readers[readers[0]]._parameter_value_map[var][0],
+                    )
                 else:
                     self.add_metadata(keyword, self.env.priority_list[var])
 
-        self.timer_end('cleaning up')
-        self.timer_end('total time')
+        self.timer_end("cleaning up")
+        self.timer_end("total time")
         if outfile is not None:
-            logger.debug('Writing and closing output file: %s' % outfile)
+            logger.debug("Writing and closing output file: %s" % outfile)
             # Write buffer to outfile, and close
             if self.steps_output >= self.steps_exported:
                 # Write last lines, if needed
@@ -2147,8 +2214,9 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             # Remove columns for unseeded elements in history array
             if self.num_elements_scheduled() > 0:
                 logger.info(
-                    'Removing %i unseeded elements from history array' %
-                    self.num_elements_scheduled())
+                    "Removing %i unseeded elements from history array"
+                    % self.num_elements_scheduled()
+                )
                 mask = np.ones(self.history.shape[0], dtype=bool)
                 mask[self.elements_scheduled.ID - 1] = False
                 self.history = self.history[mask, :]
@@ -2158,7 +2226,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         else:  # If output has been flushed to file during run, we
             # need to reimport from file to get all data in memory
             del self.environment
-            if hasattr(self, 'environment_profiles'):
+            if hasattr(self, "environment_profiles"):
                 del self.environment_profiles
             self.io_import_file(outfile)
 
@@ -2168,34 +2236,32 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         self.elements.age_seconds += self.time_step.total_seconds()
 
         # Deactivate elements that exceed a certain age
-        if self.get_config('drift:max_age_seconds') is not None:
+        if self.get_config("drift:max_age_seconds") is not None:
             self.deactivate_elements(
-                self.elements.age_seconds
-                >= self.get_config('drift:max_age_seconds'),
-                reason='retired')
+                self.elements.age_seconds >= self.get_config("drift:max_age_seconds"),
+                reason="retired",
+            )
 
         # Deacticate any elements outside validity domain set by user
         if self.validity_domain is not None:
             W, E, S, N = self.validity_domain
             if W is not None:
-                self.deactivate_elements(self.elements.lon < W,
-                                         reason='outside')
+                self.deactivate_elements(self.elements.lon < W, reason="outside")
             if E is not None:
-                self.deactivate_elements(self.elements.lon > E,
-                                         reason='outside')
+                self.deactivate_elements(self.elements.lon > E, reason="outside")
             if S is not None:
-                self.deactivate_elements(self.elements.lat < S,
-                                         reason='outside')
+                self.deactivate_elements(self.elements.lat < S, reason="outside")
             if N is not None:
-                self.deactivate_elements(self.elements.lat > N,
-                                         reason='outside')
+                self.deactivate_elements(self.elements.lat > N, reason="outside")
 
     def state_to_buffer(self):
         """Append present state (elements and environment) to recarray."""
 
-        steps_calculation_float = \
-            (self.steps_calculation * self.time_step.total_seconds() /
-             self.time_step_output.total_seconds()) + 1
+        steps_calculation_float = (
+            self.steps_calculation
+            * self.time_step.total_seconds()
+            / self.time_step_output.total_seconds()
+        ) + 1
         if self.time_step <= timedelta(seconds=1):
             self.steps_output = int(np.round(steps_calculation_float))
         else:
@@ -2203,21 +2269,26 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         ID_ind = self.elements.ID - 1
         time_ind = self.steps_output - 1 - self.steps_exported
+        # print(time_ind, self.steps_calculation, steps_calculation_float, "DEBUG")
         if self.steps_calculation == self.expected_steps_calculation:
             final_time_step = True
         else:
             final_time_step = False
 
-        if steps_calculation_float.is_integer() or self.time_step < timedelta(
-                seconds=1) or final_time_step is True:
+        if (
+            steps_calculation_float.is_integer()
+            or self.time_step < timedelta(seconds=1)
+            or final_time_step is True
+        ):
             element_ind = range(len(ID_ind))  # We write all elements
         else:
             deactivated = np.where(self.elements.status != 0)[0]
             if len(deactivated) == 0:
                 return  # No deactivated elements this sub-timestep
             # We write history for deactivated elements only:
-            logger.debug('Writing history for %s deactivated elements' %
-                         len(deactivated))
+            logger.debug(
+                "Writing history for %s deactivated elements" % len(deactivated)
+            )
             ID_ind = ID_ind[deactivated]
             element_ind = deactivated
             time_ind = np.minimum(time_ind + 1, self.history.shape[1] - 1)
@@ -2225,15 +2296,15 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         # TODO: storing of variables and environment below should be collected in a single loop
         # Store present state in history recarray
         for i, var in enumerate(self.elements.variables):
-            if self.export_variables is not None and \
-                    var not in self.export_variables:
+            if self.export_variables is not None and var not in self.export_variables:
                 continue
             # Temporarily assuming elements numbered
             # from 0 to num_elements_active()
             # Does not hold when importing ID from a saved file, where
             # some elements have been deactivated
-            self.history[var][ID_ind, time_ind] = \
-                getattr(self.elements, var)[element_ind]
+            self.history[var][ID_ind, time_ind] = getattr(self.elements, var)[
+                element_ind
+            ]
             if len(ID_ind) > 0:
                 newmin = np.min(self.history[var][ID_ind, time_ind])
                 newmax = np.max(self.history[var][ID_ind, time_ind])
@@ -2245,11 +2316,11 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                     self.maxvals[var] = np.maximum(self.maxvals[var], newmax)
         # Copy environment data to history array
         for i, var in enumerate(self.environment.dtype.names):
-            if self.export_variables is not None and \
-                    var not in self.export_variables:
+            if self.export_variables is not None and var not in self.export_variables:
                 continue
-            self.history[var][ID_ind, time_ind] = \
-                getattr(self.environment, var)[element_ind]
+            self.history[var][ID_ind, time_ind] = getattr(self.environment, var)[
+                element_ind
+            ]
             if len(ID_ind) > 0:
                 newmin = np.min(self.history[var][ID_ind, time_ind])
                 newmax = np.max(self.history[var][ID_ind, time_ind])
@@ -2261,9 +2332,9 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                     self.maxvals[var] = np.maximum(self.maxvals[var], newmax)
 
         # Call writer if buffer is full
-        if (self.outfile is not None) and \
-                ((self.steps_output - self.steps_exported) ==
-                    self.export_buffer_length):
+        if (self.outfile is not None) and (
+            (self.steps_output - self.steps_exported) == self.export_buffer_length
+        ):
             self.io_write_buffer()
 
     def report_missing_variables(self):
@@ -2275,33 +2346,37 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 missing_variables.append(var)
 
         if len(missing_variables) > 0:
-            logger.warning('Missing variables: ' + str(missing_variables))
-            self.store_message('Missing variables: ' + str(missing_variables))
+            logger.warning("Missing variables: " + str(missing_variables))
+            self.store_message("Missing variables: " + str(missing_variables))
 
     def index_of_activation_and_deactivation(self):
         """Return the indices when elements were seeded and deactivated."""
 
-        firstlast = np.ma.notmasked_edges(self.history['lon'], axis=1)
+        firstlast = np.ma.notmasked_edges(self.history["lon"], axis=1)
         index_of_activation = firstlast[0][1]
         index_of_deactivation = firstlast[1][1]
-        if len(index_of_deactivation) < self.history['lon'].shape[0]:
+        if len(index_of_deactivation) < self.history["lon"].shape[0]:
             missingind = np.setdiff1d(
-                np.arange(0, self.history['lon'].shape[0]), firstlast[0][0])
+                np.arange(0, self.history["lon"].shape[0]), firstlast[0][0]
+            )
             logger.warning(
-                '%s elements were never seeded, removing from history array (this is probably caused by importing an old file)'
-                % len(missingind))
+                "%s elements were never seeded, removing from history array (this is probably caused by importing an old file)"
+                % len(missingind)
+            )
             self.history = self.history[firstlast[0][0], :]
 
         return index_of_activation, index_of_deactivation
 
-    def set_up_map(self,
-                   corners=None,
-                   buffer=.1,
-                   delta_lat=None,
-                   lscale=None,
-                   fast=False,
-                   hide_landmask=False,
-                   **kwargs):
+    def set_up_map(
+        self,
+        corners=None,
+        buffer=0.1,
+        delta_lat=None,
+        lscale=None,
+        fast=False,
+        hide_landmask=False,
+        **kwargs,
+    ):
         """
         Generate Figure instance on which trajectories are plotted.
 
@@ -2313,17 +2388,17 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         logger.debug(f"Setting up map: {corners=}, {fast=}, {lscale=}")
 
         # Initialise map
-        if hasattr(self, 'ds'):  # If dataset is lazily imported
+        if hasattr(self, "ds"):  # If dataset is lazily imported
             lons = self.ds.lon
             lats = self.ds.lat
-            if not hasattr(self, 'lonmin'):
-                logger.debug('Finding min longitude...')
+            if not hasattr(self, "lonmin"):
+                logger.debug("Finding min longitude...")
                 self.lonmin = np.nanmin(self.ds.lon)
-                logger.debug('Finding max longitude...')
+                logger.debug("Finding max longitude...")
                 self.lonmax = np.nanmax(self.ds.lon)
-                logger.debug('Finding min latitude...')
+                logger.debug("Finding min latitude...")
                 self.latmin = np.nanmin(self.ds.lat)
-                logger.debug('Finding max latitude...')
+                logger.debug("Finding max latitude...")
                 self.latmax = np.nanmax(self.ds.lat)
         else:
             lons, lats = self.get_lonlats()  # TODO: to be removed
@@ -2333,18 +2408,20 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             lonmax = corners[1]
             latmin = corners[2]
             latmax = corners[3]
-        elif hasattr(self, 'lonmin'):  # if dataset is lazily imported
+        elif hasattr(self, "lonmin"):  # if dataset is lazily imported
             lonmin = self.lonmin - buffer * 2
             lonmax = self.lonmax + buffer * 2
             latmin = self.latmin - buffer
             latmax = self.latmax + buffer
         else:
             lons, lats = self.get_lonlats()
-            if 'compare_lonmin' in kwargs:  # checking min/max lon/lat of other simulations
-                lonmin = np.minimum(kwargs['compare_lonmin'], np.nanmin(lons))
-                lonmax = np.maximum(kwargs['compare_lonmax'], np.nanmax(lons))
-                latmin = np.minimum(kwargs['compare_latmin'], np.nanmin(lats))
-                latmax = np.maximum(kwargs['compare_latmax'], np.nanmax(lats))
+            if (
+                "compare_lonmin" in kwargs
+            ):  # checking min/max lon/lat of other simulations
+                lonmin = np.minimum(kwargs["compare_lonmin"], np.nanmin(lons))
+                lonmax = np.maximum(kwargs["compare_lonmax"], np.nanmax(lons))
+                latmin = np.minimum(kwargs["compare_latmin"], np.nanmin(lats))
+                latmax = np.maximum(kwargs["compare_latmax"], np.nanmax(lats))
             else:
                 lonmin = np.nanmin(lons)
                 lonmax = np.nanmax(lons)
@@ -2356,35 +2433,33 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             latmax = latmax + buffer
 
         if fast is True:
-            logger.warning(
-                'Plotting fast. This will make your plots less accurate.')
+            logger.warning("Plotting fast. This will make your plots less accurate.")
 
             import matplotlib.style as mplstyle
-            mplstyle.use(['fast'])
+
+            mplstyle.use(["fast"])
 
             # use a spherical earth
             axis = 57.29577951308232  # something to do with pi
-            globe = ccrs.Globe(ellipse=None,
-                               semimajor_axis=axis,
-                               semiminor_axis=axis)
+            globe = ccrs.Globe(ellipse=None, semimajor_axis=axis, semiminor_axis=axis)
             crs = ccrs.Mercator(globe=globe)
 
             if lscale is None:
-                lscale = 'c'
+                lscale = "c"
         else:
             crs = ccrs.Mercator()
             if lscale is None:
-                lscale = 'auto'
+                lscale = "auto"
 
         globe = crs.globe
 
         meanlat = (latmin + latmax) / 2
         aspect_ratio = float(latmax - latmin) / (float(lonmax - lonmin))
         aspect_ratio = aspect_ratio / np.cos(np.radians(meanlat))
-        if 'figsize' in kwargs:
-            figsize = kwargs['figsize']
+        if "figsize" in kwargs:
+            figsize = kwargs["figsize"]
         else:
-            figsize = 11.  # inches
+            figsize = 11.0  # inches
 
         if aspect_ratio > 1:
             fig = plt.figure(figsize=(figsize / aspect_ratio, figsize))
@@ -2392,77 +2467,94 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             fig = plt.figure(figsize=(figsize, figsize * aspect_ratio))
 
         ax = fig.add_subplot(111, projection=crs)
-        ax.set_extent([lonmin, lonmax, latmin, latmax],
-                      crs=ccrs.PlateCarree(globe=globe))
+        ax.set_extent(
+            [lonmin, lonmax, latmin, latmax], crs=ccrs.PlateCarree(globe=globe)
+        )
 
-        if 'ocean_color' in kwargs:
-            ax.patch.set_facecolor(kwargs['ocean_color'])
-            ocean_color = kwargs['ocean_color']
+        if "ocean_color" in kwargs:
+            ax.patch.set_facecolor(kwargs["ocean_color"])
+            ocean_color = kwargs["ocean_color"]
         else:
-            ocean_color = 'white'
-        if 'land_color' in kwargs:
-            land_color = kwargs['land_color']
+            ocean_color = "white"
+        if "land_color" in kwargs:
+            land_color = kwargs["land_color"]
         else:
             if fast is True:
-                land_color = 'gray'
+                land_color = "gray"
             else:
-                land_color = cfeature.COLORS['land']
+                land_color = cfeature.COLORS["land"]
 
-        if 'text' in kwargs:
-            if not isinstance(kwargs['text'], list):
-                text = list(kwargs['text'])
+        if "text" in kwargs:
+            if not isinstance(kwargs["text"], list):
+                text = list(kwargs["text"])
             else:
-                text = kwargs['text']
+                text = kwargs["text"]
             for te in text:
                 plt.text(transform=ccrs.Geodetic(globe=globe), **te)
 
-        if 'box' in kwargs:
-            if not isinstance(kwargs['box'], list):
-                box = list(kwargs['box'])
+        if "box" in kwargs:
+            if not isinstance(kwargs["box"], list):
+                box = list(kwargs["box"])
             else:
-                box = kwargs['box']
+                box = kwargs["box"]
             for bx in box:
-                lonmn = bx['lon'][0]
-                lonmx = bx['lon'][1]
-                latmn = bx['lat'][0]
-                latmx = bx['lat'][1]
-                del bx['lon']
-                del bx['lat']
-                if 'text' in bx:
-                    plt.text(x=lonmn,
-                             y=latmx,
-                             s=bx['text'],
-                             transform=ccrs.Geodetic(globe=globe))
-                    del bx['text']
+                lonmn = bx["lon"][0]
+                lonmx = bx["lon"][1]
+                latmn = bx["lat"][0]
+                latmx = bx["lat"][1]
+                del bx["lon"]
+                del bx["lat"]
+                if "text" in bx:
+                    plt.text(
+                        x=lonmn,
+                        y=latmx,
+                        s=bx["text"],
+                        transform=ccrs.Geodetic(globe=globe),
+                    )
+                    del bx["text"]
                 patch = matplotlib.patches.Rectangle(
                     xy=[lonmn, latmn],
                     width=lonmx - lonmn,
                     height=latmx - latmn,
                     transform=ccrs.Geodetic(globe=globe),
                     zorder=10,
-                    **bx)
+                    **bx,
+                )
                 ax.add_patch(patch)
 
         if not hide_landmask:
-            if 'land_binary_mask' in self.env.priority_list and self.env.priority_list[
-                    'land_binary_mask'][0] == 'shape':
-                logger.debug('Using custom shapes for plotting land..')
-                ax.add_geometries(self.env.readers['shape'].polys,
-                                  ccrs.PlateCarree(globe=globe),
-                                  facecolor=land_color,
-                                  edgecolor='black')
+            if (
+                "land_binary_mask" in self.env.priority_list
+                and self.env.priority_list["land_binary_mask"][0] == "shape"
+            ):
+                logger.debug("Using custom shapes for plotting land..")
+                ax.add_geometries(
+                    self.env.readers["shape"].polys,
+                    ccrs.PlateCarree(globe=globe),
+                    facecolor=land_color,
+                    edgecolor="black",
+                )
             else:
-                reader_global_landmask.plot_land(ax, lonmin, latmin, lonmax,
-                                                 latmax, fast, ocean_color,
-                                                 land_color, lscale, globe)
+                reader_global_landmask.plot_land(
+                    ax,
+                    lonmin,
+                    latmin,
+                    lonmax,
+                    latmax,
+                    fast,
+                    ocean_color,
+                    land_color,
+                    lscale,
+                    globe,
+                )
 
         gl = ax.gridlines(ccrs.PlateCarree(globe=globe), draw_labels=True)
         gl.top_labels = None
 
         fig.canvas.draw()
-        fig.set_layout_engine('tight')
+        fig.set_layout_engine("tight")
 
-        if not hasattr(self, 'ds'):
+        if not hasattr(self, "ds"):
             try:
                 firstlast = np.ma.notmasked_edges(lons, axis=1)
                 index_of_first = firstlast[0][1]
@@ -2488,82 +2580,84 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
     def get_lonlats(self):
         if self.history is not None:
-            lons = self.history['lon']
-            lats = self.history['lat']
+            lons = self.history["lon"]
+            lats = self.history["lat"]
         else:
             if self.steps_output > 0:
                 lons = np.ma.array(np.reshape(self.elements.lon, (1, -1))).T
                 lats = np.ma.array(np.reshape(self.elements.lat, (1, -1))).T
             else:
-                lons = np.ma.array(
-                    np.reshape(self.elements_scheduled.lon, (1, -1))).T
-                lats = np.ma.array(
-                    np.reshape(self.elements_scheduled.lat, (1, -1))).T
+                lons = np.ma.array(np.reshape(self.elements_scheduled.lon, (1, -1))).T
+                lats = np.ma.array(np.reshape(self.elements_scheduled.lat, (1, -1))).T
         return lons, lats
 
-    def animation(self,
-                  buffer=.2,
-                  corners=None,
-                  filename=None,
-                  compare=None,
-                  compare_marker='o',
-                  background=None,
-                  bgalpha=.5,
-                  vmin=None,
-                  vmax=None,
-                  drifter=None,
-                  shapefiles=None,
-                  skip=None,
-                  scale=None,
-                  color=False,
-                  clabel=None,
-                  colorbar=True,
-                  cmap=None,
-                  density=False,
-                  show_elements=True,
-                  show_trajectories=False,
-                  trajectory_alpha=.1,
-                  hide_landmask=False,
-                  density_pixelsize_m=1000,
-                  unitfactor=1,
-                  lcs=None,
-                  surface_only=False,
-                  markersize=20,
-                  origin_marker=None,
-                  legend=None,
-                  legend_loc='best',
-                  title='auto',
-                  fps=8,
-                  lscale=None,
-                  fast=False,
-                  blit=False,
-                  **kwargs):
+    def animation(
+        self,
+        buffer=0.2,
+        corners=None,
+        filename=None,
+        compare=None,
+        compare_marker="o",
+        background=None,
+        bgalpha=0.5,
+        vmin=None,
+        vmax=None,
+        drifter=None,
+        shapefiles=None,
+        skip=None,
+        scale=None,
+        color=False,
+        clabel=None,
+        colorbar=True,
+        cmap=None,
+        density=False,
+        show_elements=True,
+        show_trajectories=False,
+        trajectory_alpha=0.1,
+        hide_landmask=False,
+        density_pixelsize_m=1000,
+        unitfactor=1,
+        lcs=None,
+        surface_only=False,
+        markersize=20,
+        origin_marker=None,
+        legend=None,
+        legend_loc="best",
+        title="auto",
+        fps=8,
+        lscale=None,
+        fast=False,
+        blit=False,
+        **kwargs,
+    ):
         """Animate last run."""
 
         filename = str(filename) if filename is not None else None
 
-        if self.history is not None and self.num_elements_total(
-        ) == 0 and not hasattr(self, 'ds'):
-            raise ValueError('Please run simulation before animating')
+        if (
+            self.history is not None
+            and self.num_elements_total() == 0
+            and not hasattr(self, "ds")
+        ):
+            raise ValueError("Please run simulation before animating")
 
         if compare is not None:
-            compare_list, compare_args = self._get_comparison_xy_for_plots(
-                compare)
+            compare_list, compare_args = self._get_comparison_xy_for_plots(compare)
             kwargs.update(compare_args)
 
         markersizebymass = False
         if isinstance(markersize, str):
-            if markersize.startswith('mass'):
+            if markersize.startswith("mass"):
                 markersizebymass = True
-                if markersize[len('mass'):] == '':
+                if markersize[len("mass") :] == "":
                     # default initial size if not specified
                     markersize = 100
                 else:
-                    markersize = int(markersize[len('mass'):])
+                    markersize = int(markersize[len("mass") :])
 
         start_time = datetime.now()
         if cmap is None:
-            cmap = 'jet'
+            cmap = "jet"
         if isinstance(cmap, str):
             cmap = matplotlib.colormaps[cmap]
 
@@ -2584,67 +2678,80 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 density_weight = density
                 density = True
         if density is True:  # Get density arrays
-            if hasattr(self, 'ds'):  # opened with Xarray
+            if hasattr(self, "ds"):  # opened with Xarray
                 if origin_marker is None:
                     origin_marker = 0
                     per_origin_marker = False
                 else:
                     per_origin_marker = True
                 H, H_om, lon_array, lat_array = self.get_density_xarray(
-                    pixelsize_m=density_pixelsize_m, weights=density_weight)
+                    pixelsize_m=density_pixelsize_m, weights=density_weight
+                )
                 if per_origin_marker is True:
                     H = H_om[:, :, :, origin_marker]
             else:
                 if origin_marker is not None:
                     raise ValueError(
-                        'Separation by origin_marker is only active when imported from file with '
-                        'open_xarray: https://opendrift.github.io/gallery/example_huge_output.html'
+                        "Separation by origin_marker is only active when imported from file with "
+                        "open_xarray: https://opendrift.github.io/gallery/example_huge_output.html"
                     )
-                H, H_submerged, H_stranded, lon_array, lat_array = \
-                    self.get_density_array(pixelsize_m=density_pixelsize_m,
-                                           weight=density_weight)
+                H, H_submerged, H_stranded, lon_array, lat_array = (
+                    self.get_density_array(
+                        pixelsize_m=density_pixelsize_m, weight=density_weight
+                    )
+                )
                 H = H + H_submerged + H_stranded
 
         # Find map coordinates and plot points with empty data
-        fig, ax, crs, x, y, index_of_first, index_of_last = \
-            self.set_up_map(buffer=buffer, corners=corners, lscale=lscale,
-                            fast=fast, hide_landmask=hide_landmask, **kwargs)
+        fig, ax, crs, x, y, index_of_first, index_of_last = self.set_up_map(
+            buffer=buffer,
+            corners=corners,
+            lscale=lscale,
+            fast=fast,
+            hide_landmask=hide_landmask,
+            **kwargs,
+        )
 
         gcrs = ccrs.PlateCarree(globe=crs.globe)
 
         def plot_timestep(i):
             """Sub function needed for matplotlib animation."""
 
-            ret = [points, points_deactivated
-                   ]  # list of elements to return for blitting
-            if title == 'auto':
-                ax.set_title('%s\n%s UTC' % (self._figure_title(), times[i]))
+            ret = [
+                points,
+                points_deactivated,
+            ]  # list of elements to return for blitting
+            if title == "auto":
+                ax.set_title("%s\n%s UTC" % (self._figure_title(), times[i]))
             else:
-                ax.set_title('%s\n%s UTC' % (title, times[i]))
+                ax.set_title("%s\n%s UTC" % (title, times[i]))
             if background is not None:
                 ret.append(bg)
                 if isinstance(background, xr.DataArray):
                     scalar = background[i, :, :].values
                 else:
-                    map_x, map_y, scalar, u_component, v_component = \
-                        self.get_map_background(ax, background, crs,
-                                                time=times[i])
+                    map_x, map_y, scalar, u_component, v_component = (
+                        self.get_map_background(ax, background, crs, time=times[i])
+                    )
                 # https://stackoverflow.com/questions/18797175/animation-with-pcolormesh-routine-in-matplotlib-how-do-i-initialize-the-data
                 bg.set_array(scalar.ravel())
                 if type(background) is list:
                     ret.append(bg_quiv)
-                    bg_quiv.set_UVC(u_component[::skip, ::skip],
-                                    v_component[::skip, ::skip])
+                    bg_quiv.set_UVC(
+                        u_component[::skip, ::skip], v_component[::skip, ::skip]
+                    )
 
             if lcs is not None:
-                ax.pcolormesh(lcs['lon'],
-                              lcs['lat'],
-                              lcs['ALCS'][i, :, :],
-                              alpha=bgalpha,
-                              vmin=vmin,
-                              vmax=vmax,
-                              cmap=cmap,
-                              transform=gcrs)
+                ax.pcolormesh(
+                    lcs["lon"],
+                    lcs["lat"],
+                    lcs["ALCS"][i, :, :],
+                    alpha=bgalpha,
+                    vmin=vmin,
+                    vmax=vmax,
+                    cmap=cmap,
+                    transform=gcrs,
+                )
 
             if density is True:
                 # Update density plot
@@ -2653,91 +2760,116 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
             # Move points
             if show_elements is True:
-                points.set_offsets(np.c_[x[i, range(x.shape[1])],
-                                         y[i, range(x.shape[1])]])
+                points.set_offsets(
+                    np.c_[x[i, range(x.shape[1])], y[i, range(x.shape[1])]]
+                )
                 points_deactivated.set_offsets(
-                    np.c_[x_deactive[index_of_last_deactivated < i],
-                          y_deactive[index_of_last_deactivated < i]])
+                    np.c_[
+                        x_deactive[index_of_last_deactivated < i],
+                        y_deactive[index_of_last_deactivated < i],
+                    ]
+                )
 
                 if markersizebymass:
-                    if 'chemicaldrift' in self.__module__:
+                    if "chemicaldrift" in self.__module__:
                         points.set_sizes(
-                            markersize *
-                            (self.history['mass'][:, i] /
-                             (self.history['mass'][:, i] +
-                              self.history['mass_degraded'][:, i] +
-                              self.history['mass_volatilized'][:, i])))
-                    elif 'openoil' in self.__module__:
+                            markersize
+                            * (
+                                self.history["mass"][:, i]
+                                / (
+                                    self.history["mass"][:, i]
+                                    + self.history["mass_degraded"][:, i]
+                                    + self.history["mass_volatilized"][:, i]
+                                )
+                            )
+                        )
+                    elif "openoil" in self.__module__:
                         points.set_sizes(
-                            markersize *
-                            (self.history['mass_oil'][:, i] /
-                             (self.history['mass_oil'][:, i] +
-                              self.history['mass_biodegraded'][:, i] +
-                              self.history['mass_dispersed'][:, i] +
-                              self.history['mass_evaporated'][:, i])))
+                            markersize
+                            * (
+                                self.history["mass_oil"][:, i]
+                                / (
+                                    self.history["mass_oil"][:, i]
+                                    + self.history["mass_biodegraded"][:, i]
+                                    + self.history["mass_dispersed"][:, i]
+                                    + self.history["mass_evaporated"][:, i]
+                                )
+                            )
+                        )
 
                 if color is not False:  # Update colors
                     points.set_array(colorarray[:, i])
                     if compare is not None:
                         for cd in compare_list:
-                            cd['points_other'].set_array(colorarray[:, i])
-                    if isinstance(color, str) or hasattr(color, '__len__'):
-                        points_deactivated.set_array(colorarray_deactivated[
-                            index_of_last_deactivated < i])
+                            cd["points_other"].set_array(colorarray[:, i])
+                    if isinstance(color, str) or hasattr(color, "__len__"):
+                        points_deactivated.set_array(
+                            colorarray_deactivated[index_of_last_deactivated < i]
+                        )
 
             if drifter is not None:
                 for drnum, dr in enumerate(drifter):
-                    drifter_pos[drnum].set_offsets(np.c_[dr['x'][i],
-                                                         dr['y'][i]])
-                    drifter_line[drnum].set_data(dr['x'][0:i], dr['y'][0:i])
+                    drifter_pos[drnum].set_offsets(np.c_[dr["x"][i], dr["y"][i]])
+                    drifter_line[drnum].set_data(dr["x"][0:i], dr["y"][0:i])
                     ret.append(drifter_line[drnum])
                     ret.append(drifter_pos[drnum])
 
             if shapefiles is not None:
                 import geopandas as gpd
+
                 for sf in shapefiles:
                     shdf = gpd.read_file(sf)
                     shdf = shdf.to_crs("EPSG:4326")
-                    ax.add_geometries(shdf.geometry, gcrs, edgecolor='g', linewidth=2, facecolor='none')
+                    ax.add_geometries(
+                        shdf.geometry,
+                        gcrs,
+                        edgecolor="g",
+                        linewidth=2,
+                        facecolor="none",
+                    )
 
             if show_elements is True:
                 if compare is not None:
                     for cd in compare_list:
-                        cd['points_other'].set_offsets(
-                            np.c_[cd['x_other'][range(cd['x_other'].shape[0]),
-                                                i],
-                                  cd['y_other'][range(cd['x_other'].shape[0]),
-                                                i]])
-                        cd['points_other_deactivated'].set_offsets(np.c_[
-                            cd['x_other_deactive'][
-                                cd['index_of_last_deactivated_other'] < i],
-                            cd['y_other_deactive'][
-                                cd['index_of_last_deactivated_other'] < i]])
-                        ret.append(cd['points_other'])
-                        ret.append(cd['points_other_deactivated'])
+                        cd["points_other"].set_offsets(
+                            np.c_[
+                                cd["x_other"][range(cd["x_other"].shape[0]), i],
+                                cd["y_other"][range(cd["x_other"].shape[0]), i],
+                            ]
+                        )
+                        cd["points_other_deactivated"].set_offsets(
+                            np.c_[
+                                cd["x_other_deactive"][
+                                    cd["index_of_last_deactivated_other"] < i
+                                ],
+                                cd["y_other_deactive"][
+                                    cd["index_of_last_deactivated_other"] < i
+                                ],
+                            ]
+                        )
+                        ret.append(cd["points_other"])
+                        ret.append(cd["points_other_deactivated"])
 
             return ret
 
         if surface_only is True:
-            z = self.get_property('z')[0]
+            z = self.get_property("z")[0]
             x[z < 0] = np.nan
             y[z < 0] = np.nan
 
         if show_trajectories is True:
-            ax.plot(x, y, color='gray', alpha=trajectory_alpha, transform=gcrs)
+            ax.plot(x, y, color="gray", alpha=trajectory_alpha, transform=gcrs)
 
         if color is not False and show_elements is True:
             if isinstance(color, str):
                 colorarray = self.get_property(color)[0].T
                 colorarray = colorarray * unitfactor
-                colorarray_deactivated = \
-                    self.get_property(color)[0][
-                        index_of_last[self.elements_deactivated.ID-1],
-                                      self.elements_deactivated.ID-1].T
-            elif hasattr(color,
-                         '__len__'):  # E.g. array/list of ensemble numbers
-                colorarray_deactivated = color[self.elements_deactivated.ID -
-                                               1]
+                colorarray_deactivated = self.get_property(color)[0][
+                    index_of_last[self.elements_deactivated.ID - 1],
+                    self.elements_deactivated.ID - 1,
+                ].T
+            elif hasattr(color, "__len__"):  # E.g. array/list of ensemble numbers
+                colorarray_deactivated = color[self.elements_deactivated.ID - 1]
                 colorarray = np.tile(color, (self.steps_output, 1)).T
             else:
                 colorarray = color
@@ -2747,53 +2879,58 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         if background is not None:
             if isinstance(background, xr.DataArray):
-                map_x = background.coords['lon_bin']
-                map_y = background.coords['lat_bin']
+                map_x = background.coords["lon_bin"]
+                map_y = background.coords["lat_bin"]
                 scalar = background[0, :, :]
                 map_y, map_x = np.meshgrid(map_y, map_x)
             else:
-                map_x, map_y, scalar, u_component, v_component = \
-                    self.get_map_background(ax, background, crs,
-                                            time=self.start_time)
-            bg = ax.pcolormesh(map_x,
-                               map_y,
-                               scalar,
-                               alpha=bgalpha,
-                               zorder=1,
-                               antialiased=True,
-                               linewidth=0.0,
-                               rasterized=True,
-                               vmin=vmin,
-                               vmax=vmax,
-                               cmap=cmap,
-                               transform=gcrs)
+                map_x, map_y, scalar, u_component, v_component = (
+                    self.get_map_background(ax, background, crs, time=self.start_time)
+                )
+            bg = ax.pcolormesh(
+                map_x,
+                map_y,
+                scalar,
+                alpha=bgalpha,
+                zorder=1,
+                antialiased=True,
+                linewidth=0.0,
+                rasterized=True,
+                vmin=vmin,
+                vmax=vmax,
+                cmap=cmap,
+                transform=gcrs,
+            )
             if type(background) is list:
-                bg_quiv = ax.quiver(map_x[::skip, ::skip],
-                                    map_y[::skip, ::skip],
-                                    u_component[::skip, ::skip],
-                                    v_component[::skip, ::skip],
-                                    scale=scale,
-                                    zorder=1,
-                                    transform=gcrs)
+                bg_quiv = ax.quiver(
+                    map_x[::skip, ::skip],
+                    map_y[::skip, ::skip],
+                    u_component[::skip, ::skip],
+                    v_component[::skip, ::skip],
+                    scale=scale,
+                    zorder=1,
+                    transform=gcrs,
+                )
 
         if lcs is not None:
             if vmin is None:
-                vmin = lcs['ALCS'].min()
-                vmax = lcs['ALCS'].max()
-            lcsh = ax.pcolormesh(lcs['lon'],
-                                 lcs['lat'],
-                                 lcs['ALCS'][0, :, :],
-                                 vmin=vmin,
-                                 vmax=vmax,
-                                 cmap=cmap,
-                                 transform=gcrs)
+                vmin = lcs["ALCS"].min()
+                vmax = lcs["ALCS"].max()
+            lcsh = ax.pcolormesh(
+                lcs["lon"],
+                lcs["lat"],
+                lcs["ALCS"][0, :, :],
+                vmin=vmin,
+                vmax=vmax,
+                cmap=cmap,
+                transform=gcrs,
+            )
 
         times = self.get_time_array()[0]
         if show_elements is True:
-            index_of_last_deactivated = \
-                index_of_last[self.elements_deactivated.ID-1]
+            index_of_last_deactivated = index_of_last[self.elements_deactivated.ID - 1]
         if legend is None:
-            legend = ['']
+            legend = [""]
 
         if color is False:
             c = markercolor
@@ -2801,76 +2938,92 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             c = []
 
         if markersizebymass:
-            points = ax.scatter([], [],
-                                c=c,
-                                zorder=10,
-                                edgecolor=[],
-                                cmap=cmap,
-                                alpha=.4,
-                                vmin=vmin,
-                                vmax=vmax,
-                                label=legend[0],
-                                transform=gcrs)
+            points = ax.scatter(
+                [],
+                [],
+                c=c,
+                zorder=10,
+                edgecolor=[],
+                cmap=cmap,
+                alpha=0.4,
+                vmin=vmin,
+                vmax=vmax,
+                label=legend[0],
+                transform=gcrs,
+            )
         else:
-            points = ax.scatter([], [],
-                                c=c,
-                                zorder=10,
-                                edgecolor=[],
-                                cmap=cmap,
-                                s=markersize,
-                                vmin=vmin,
-                                vmax=vmax,
-                                label=legend[0],
-                                transform=gcrs)
+            points = ax.scatter(
+                [],
+                [],
+                c=c,
+                zorder=10,
+                edgecolor=[],
+                cmap=cmap,
+                s=markersize,
+                vmin=vmin,
+                vmax=vmax,
+                label=legend[0],
+                transform=gcrs,
+            )
 
-        if (compare is None) and (legend != ['']):
+        if (compare is None) and (legend != [""]):
             markers = []
             for legend_index in np.arange(len(legend)):
-                if legend[legend_index] != '':
+                if legend[legend_index] != "":
                     markers.append(
                         matplotlib.lines.Line2D(
-                            [0], [0],
-                            marker='o',
-                            color='w',
+                            [0],
+                            [0],
+                            marker="o",
+                            color="w",
                             linewidth=0,
                             markeredgewidth=0,
-                            markerfacecolor=cmap(legend_index /
-                                                 (len(legend) - 1)),
+                            markerfacecolor=cmap(legend_index / (len(legend) - 1)),
                             markersize=10,
-                            label=legend[legend_index]))
+                            label=legend[legend_index],
+                        )
+                    )
             legend = list(filter(None, legend))
             ax.legend(markers, legend, loc=legend_loc)
 
         # Plot deactivated elements, with transparency
         if markersizebymass:
-            points_deactivated = ax.scatter([], [],
-                                            c=c,
-                                            zorder=9,
-                                            vmin=vmin,
-                                            vmax=vmax,
-                                            s=markersize,
-                                            cmap=cmap,
-                                            edgecolor=[],
-                                            alpha=0,
-                                            transform=gcrs)
+            points_deactivated = ax.scatter(
+                [],
+                [],
+                c=c,
+                zorder=9,
+                vmin=vmin,
+                vmax=vmax,
+                s=markersize,
+                cmap=cmap,
+                edgecolor=[],
+                alpha=0,
+                transform=gcrs,
+            )
         else:
-            points_deactivated = ax.scatter([], [],
-                                            c=c,
-                                            zorder=9,
-                                            vmin=vmin,
-                                            vmax=vmax,
-                                            s=markersize,
-                                            cmap=cmap,
-                                            edgecolor=[],
-                                            alpha=.3,
-                                            transform=gcrs)
+            points_deactivated = ax.scatter(
+                [],
+                [],
+                c=c,
+                zorder=9,
+                vmin=vmin,
+                vmax=vmax,
+                s=markersize,
+                cmap=cmap,
+                edgecolor=[],
+                alpha=0.3,
+                transform=gcrs,
+            )
 
-        x_deactive, y_deactive = (self.elements_deactivated.lon,
-                                  self.elements_deactivated.lat)
+        x_deactive, y_deactive = (
+            self.elements_deactivated.lon,
+            self.elements_deactivated.lat,
+        )
 
         if compare is not None:
             for cn, cd in enumerate(compare_list):
-                if legend != ['']:
+                if legend != [""]:
                     legstr = legend[cn + 1]
                 else:
                     legstr = None
@@ -2878,30 +3031,48 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                     c = self.plot_comparison_colors[cn + 1]
                 else:
                     c = []
-                cd['points_other'] = \
-                    ax.scatter([], [], c=c, marker=compare_marker, cmap=cmap,
-                               s=markersize, label=legstr, zorder=10, transform = gcrs)
+                cd["points_other"] = ax.scatter(
+                    [],
+                    [],
+                    c=c,
+                    marker=compare_marker,
+                    cmap=cmap,
+                    s=markersize,
+                    label=legstr,
+                    zorder=10,
+                    transform=gcrs,
+                )
                 # Plot deactivated elements, with transparency
-                cd['points_other_deactivated'] = \
-                    ax.scatter([], [], alpha=.3, zorder=9, marker=compare_marker, cmap=cmap,
-                               c=c, s=markersize, transform = gcrs)
+                cd["points_other_deactivated"] = ax.scatter(
+                    [],
+                    [],
+                    alpha=0.3,
+                    zorder=9,
+                    marker=compare_marker,
+                    cmap=cmap,
+                    c=c,
+                    s=markersize,
+                    transform=gcrs,
+                )
 
-            if legend != ['', '']:
+            if legend != ["", ""]:
                 plt.legend(markerscale=2, loc=legend_loc)
 
         if density is True:
-            cmap.set_under('w')
+            cmap.set_under("w")
             H = np.ma.masked_where(H == 0, H)
             lat_array, lon_array = np.meshgrid(lat_array, lon_array)
             if vmax is None:
                 vmax = H.max()
-            pm = ax.pcolormesh(lon_array,
-                               lat_array,
-                               H[0, :, :],
-                               vmin=0.1,
-                               vmax=vmax,
-                               cmap=cmap,
-                               transform=gcrs)
+            pm = ax.pcolormesh(
+                lon_array,
+                lat_array,
+                H[0, :, :],
+                vmin=0.1,
+                vmax=vmax,
+                cmap=cmap,
+                transform=gcrs,
+            )
 
         if drifter is not None:
             if not isinstance(drifter, list):
@@ -2910,34 +3081,39 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             drifter_line = [None] * len(drifter)
             for drnum, dr in enumerate(drifter):
                 # Interpolate drifter time series onto simulation times
-                sts = np.array(
-                    [t.total_seconds() for t in np.array(times) - times[0]])
-                dts = np.array([
-                    t.total_seconds() for t in np.array(dr['time']) - times[0]
-                ])
-                dr['x'] = np.interp(sts, dts, dr['lon'])
-                dr['y'] = np.interp(sts, dts, dr['lat'])
-                dr['x'][sts < dts[0]] = np.nan
-                dr['x'][sts > dts[-1]] = np.nan
-                dr['y'][sts < dts[0]] = np.nan
-                dr['y'][sts > dts[-1]] = np.nan
-                dlabel = dr['label'] if 'label' in dr else 'Drifter'
-                dcolor = dr['color'] if 'color' in dr else 'r'
-                dlinewidth = dr['linewidth'] if 'linewidth' in dr else 2
-                dzorder = dr['zorder'] if 'zorder' in dr else 10
-                dmarkersize = dr['markersize'] if 'markersize' in dr else 20
-                drifter_pos[drnum] = ax.scatter([], [],
-                                                c=dcolor,
-                                                zorder=dzorder + 1,
-                                                s=dmarkersize,
-                                                label=dlabel,
-                                                transform=gcrs)
-                drifter_line[drnum] = ax.plot([], [],
-                                              color=dcolor,
-                                              linewidth=dlinewidth,
-                                              zorder=dzorder,
-                                              transform=gcrs)[0]
-                #ax.plot(dr['x'],
+                sts = np.array([t.total_seconds() for t in np.array(times) - times[0]])
+                dts = np.array(
+                    [t.total_seconds() for t in np.array(dr["time"]) - times[0]]
+                )
+                dr["x"] = np.interp(sts, dts, dr["lon"])
+                dr["y"] = np.interp(sts, dts, dr["lat"])
+                dr["x"][sts < dts[0]] = np.nan
+                dr["x"][sts > dts[-1]] = np.nan
+                dr["y"][sts < dts[0]] = np.nan
+                dr["y"][sts > dts[-1]] = np.nan
+                dlabel = dr["label"] if "label" in dr else "Drifter"
+                dcolor = dr["color"] if "color" in dr else "r"
+                dlinewidth = dr["linewidth"] if "linewidth" in dr else 2
+                dzorder = dr["zorder"] if "zorder" in dr else 10
+                dmarkersize = dr["markersize"] if "markersize" in dr else 20
+                drifter_pos[drnum] = ax.scatter(
+                    [],
+                    [],
+                    c=dcolor,
+                    zorder=dzorder + 1,
+                    s=dmarkersize,
+                    label=dlabel,
+                    transform=gcrs,
+                )
+                drifter_line[drnum] = ax.plot(
+                    [],
+                    [],
+                    color=dcolor,
+                    linewidth=dlinewidth,
+                    zorder=dzorder,
+                    transform=gcrs,
+                )[0]
+                # ax.plot(dr['x'],
                 #        dr['y'],
                 #        color=dcolor,
                 #        linewidth=dlinewidth,
@@ -2946,7 +3122,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             plt.legend()
 
         fig.canvas.draw()
-        fig.set_layout_engine('tight')
+        fig.set_layout_engine("tight")
         if colorbar is True:
             if color is not False:
                 if isinstance(color, str) or clabel is not None:
@@ -2956,11 +3132,11 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             elif density is not False:
                 item = pm
                 if clabel is None:
-                    clabel = 'density'
+                    clabel = "density"
             elif lcs is not None:
                 item = lcsh
                 if clabel is None:
-                    clabel = 'LCS'
+                    clabel = "LCS"
             elif background is not None:
                 item = bg
                 if clabel is None:
@@ -2969,53 +3145,51 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                     else:
                         clabel = background
 
-            cb = fig.colorbar(item,
-                              orientation='horizontal',
-                              pad=.05,
-                              aspect=30,
-                              shrink=.8,
-                              drawedges=False)
+            cb = fig.colorbar(
+                item,
+                orientation="horizontal",
+                pad=0.05,
+                aspect=30,
+                shrink=0.8,
+                drawedges=False,
+            )
             cb.set_label(clabel)
 
         frames = x.shape[0]
 
         if compare is not None:
-            frames = min(x.shape[0], cd['x_other'].shape[1])
+            frames = min(x.shape[0], cd["x_other"].shape[1])
 
         # blit is now provided to animation()
-        #blit = sys.platform != 'darwin'  # blitting does not work on mac os
+        # blit = sys.platform != 'darwin'  # blitting does not work on mac os
 
-        self.__save_or_plot_animation__(plt.gcf(),
-                                        plot_timestep,
-                                        filename,
-                                        frames,
-                                        fps,
-                                        interval=50,
-                                        blit=blit)
+        self.__save_or_plot_animation__(
+            plt.gcf(), plot_timestep, filename, frames, fps, interval=50, blit=blit
+        )
 
-        logger.info('Time to make animation: %s' %
-                    (datetime.now() - start_time))
+        logger.info("Time to make animation: %s" % (datetime.now() - start_time))
 
-    def __save_or_plot_animation__(self, figure, plot_timestep, filename,
-                                   frames, fps, interval, blit):
+    def __save_or_plot_animation__(
+        self, figure, plot_timestep, filename, frames, fps, interval, blit
+    ):
 
-        if filename is not None or 'sphinx_gallery' in sys.modules:
+        if filename is not None or "sphinx_gallery" in sys.modules:
             logger.debug("Saving animation..")
-            self.__save_animation__(figure,
-                                    plot_timestep,
-                                    filename,
-                                    frames=frames,
-                                    fps=fps,
-                                    blit=blit,
-                                    interval=interval)
+            self.__save_animation__(
+                figure,
+                plot_timestep,
+                filename,
+                frames=frames,
+                fps=fps,
+                blit=blit,
+                interval=interval,
+            )
 
         else:
             logger.debug("Showing animation..")
-            anim = animation.FuncAnimation(figure,
-                                           plot_timestep,
-                                           blit=blit,
-                                           frames=frames,
-                                           interval=interval)
+            anim = animation.FuncAnimation(
+                figure, plot_timestep, blit=blit, frames=frames, interval=interval
+            )
             try:
                 plt.show()
             except AttributeError as e:
@@ -3023,53 +3197,64 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 pass
 
     @require_mode(mode=Mode.Result)
-    def animation_profile(self,
-                          filename=None,
-                          compare=None,
-                          legend=['', ''],
-                          markersize=5,
-                          fps=20,
-                          color=None,
-                          cmap=None,
-                          vmin=None,
-                          vmax=None,
-                          legend_loc=None):
+    def animation_profile(
+        self,
+        filename=None,
+        compare=None,
+        legend=["", ""],
+        markersize=5,
+        fps=20,
+        color=None,
+        cmap=None,
+        vmin=None,
+        vmax=None,
+        legend_loc=None,
+    ):
         """Animate vertical profile of the last run."""
 
         start_time = datetime.now()
 
         def plot_timestep(i):
             """Sub function needed for matplotlib animation."""
-            #plt.gcf().gca().set_title(str(i))
-            ax.set_title('%s UTC' % times[i])
+            # plt.gcf().gca().set_title(str(i))
+            ax.set_title("%s UTC" % times[i])
             if PlotColors:
                 points.set_offsets(
-                    np.array(
-                        [x[range(x.shape[0]), i].T, z[range(x.shape[0]),
-                                                      i].T]).T)
+                    np.array([x[range(x.shape[0]), i].T, z[range(x.shape[0]), i].T]).T
+                )
                 points.set_array(colorarray[:, i])
             else:
-                points.set_data(x[range(x.shape[0]), i], z[range(x.shape[0]),
-                                                           i])
+                points.set_data(x[range(x.shape[0]), i], z[range(x.shape[0]), i])
 
             points_deactivated.set_data(
                 x_deactive[index_of_last_deactivated < i],
-                z_deactive[index_of_last_deactivated < i])
+                z_deactive[index_of_last_deactivated < i],
+            )
 
             if compare is not None:
-                points_other.set_data(x_other[range(x_other.shape[0]), i],
-                                      z_other[range(x_other.shape[0]), i])
+                points_other.set_data(
+                    x_other[range(x_other.shape[0]), i],
+                    z_other[range(x_other.shape[0]), i],
+                )
                 points_other_deactivated.set_data(
                     x_other_deactive[index_of_last_deactivated_other < i],
-                    z_other_deactive[index_of_last_deactivated_other < i])
-                return points, points_deactivated, points_other,
+                    z_other_deactive[index_of_last_deactivated_other < i],
+                )
+                return (
+                    points,
+                    points_deactivated,
+                    points_other,
+                )
             else:
-                return points, points_deactivated,
+                return (
+                    points,
+                    points_deactivated,
+                )
 
-        PlotColors = (compare is None) and (legend != ['', ''])
+        PlotColors = (compare is None) and (legend != ["", ""])
         if PlotColors:
             if cmap is None:
-                cmap = 'jet'
+                cmap = "jet"
             if isinstance(cmap, str):
                 cmap = matplotlib.cm.get_cmap(cmap)
 
@@ -3078,54 +3263,54 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                     colorarray = self.get_property(color)[0].T
 
         # Set up plot
-        index_of_first, index_of_last = \
-            self.index_of_activation_and_deactivation()
-        z = self.get_property('z')[0].T
-        x = self.get_property('lon')[0].T
+        index_of_first, index_of_last = self.index_of_activation_and_deactivation()
+        z = self.get_property("z")[0].T
+        x = self.get_property("lon")[0].T
 
-        #seafloor_depth = \
+        # seafloor_depth = \
         #    -self.get_property('sea_floor_depth_below_sea_level')[0].T
-        fig = plt.figure(figsize=(10, 6.))  # Suitable aspect ratio
+        fig = plt.figure(figsize=(10, 6.0))  # Suitable aspect ratio
         ax = fig.gca()
-        plt.xlabel('Longitude [degrees]')
-        plt.ylabel('Depth [m]')
+        plt.xlabel("Longitude [degrees]")
+        plt.ylabel("Depth [m]")
         times = self.get_time_array()[0]
-        index_of_last_deactivated = \
-            index_of_last[self.elements_deactivated.ID-1]
+        index_of_last_deactivated = index_of_last[self.elements_deactivated.ID - 1]
         if PlotColors:
-            points = ax.scatter([], [],
-                                c=[],
-                                zorder=10,
-                                edgecolor=[],
-                                cmap=cmap,
-                                s=markersize,
-                                vmin=vmin,
-                                vmax=vmax)
+            points = ax.scatter(
+                [],
+                [],
+                c=[],
+                zorder=10,
+                edgecolor=[],
+                cmap=cmap,
+                s=markersize,
+                vmin=vmin,
+                vmax=vmax,
+            )
 
             markers = []
             for legend_index in np.arange(len(legend)):
-                if legend[legend_index] != '':
+                if legend[legend_index] != "":
                     markers.append(
                         matplotlib.lines.Line2D(
-                            [0], [0],
-                            marker='o',
+                            [0],
+                            [0],
+                            marker="o",
                             linewidth=0,
                             markeredgewidth=0,
-                            markerfacecolor=cmap(legend_index /
-                                                 (len(legend) - 1)),
+                            markerfacecolor=cmap(legend_index / (len(legend) - 1)),
                             markersize=10,
-                            label=legend[legend_index]))
+                            label=legend[legend_index],
+                        )
+                    )
             legend = list(filter(None, legend))
             leg = ax.legend(markers, legend, loc=legend_loc)
             leg.set_zorder(20)
         else:
-            points = plt.plot([], [],
-                              '.k',
-                              label=legend[0],
-                              markersize=markersize)[0]
+            points = plt.plot([], [], ".k", label=legend[0], markersize=markersize)[0]
 
         # Plot deactivated elements, with transparency
-        points_deactivated = plt.plot([], [], '.k', alpha=.3)[0]
+        points_deactivated = plt.plot([], [], ".k", alpha=0.3)[0]
         x_deactive = self.elements_deactivated.lon
         z_deactive = self.elements_deactivated.z
 
@@ -3137,21 +3322,24 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             else:
                 # Other is given as an OpenDrift object
                 other = compare
-            z_other = other.get_property('z')[0].T
-            x_other = self.get_property('lon')[0].T
-            points_other = plt.plot(x_other[0, 0],
-                                    z_other[0, 0],
-                                    '.r',
-                                    label=legend[1],
-                                    markersize=markersize)[0]
+            z_other = other.get_property("z")[0].T
+            x_other = self.get_property("lon")[0].T
+            points_other = plt.plot(
+                x_other[0, 0],
+                z_other[0, 0],
+                ".r",
+                label=legend[1],
+                markersize=markersize,
+            )[0]
             # Plot deactivated elements, with transparency
-            points_other_deactivated = plt.plot([], [], '.r', alpha=.3)[0]
+            points_other_deactivated = plt.plot([], [], ".r", alpha=0.3)[0]
             x_other_deactive = other.elements_deactivated.lon
             z_other_deactive = other.elements_deactivated.z
             firstlast = np.ma.notmasked_edges(x_other, axis=1)
             index_of_last_other = firstlast[1][1]
-            index_of_last_deactivated_other = \
-                index_of_last_other[other.elements_deactivated.ID-1]
+            index_of_last_deactivated_other = index_of_last_other[
+                other.elements_deactivated.ID - 1
+            ]
             xmax = np.maximum(x.max(), x_other.max())
             xmin = np.minimum(x.min(), x_other.min())
             zmax = np.maximum(z.max(), z_other.max())
@@ -3163,30 +3351,28 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             zmax = z.max()
 
         # Set figure limits
-        sky = (zmax - zmin) * .1  # Sky height is 10% of water depth
+        sky = (zmax - zmin) * 0.1  # Sky height is 10% of water depth
         plt.xlim([xmin, xmax])
         plt.ylim([zmin, sky])
+        ax.add_patch(plt.Rectangle((xmin, 0), xmax - xmin, sky, color="lightsteelblue"))
         ax.add_patch(
-            plt.Rectangle((xmin, 0), xmax - xmin, sky, color='lightsteelblue'))
-        ax.add_patch(
-            plt.Rectangle((xmin, zmin),
-                          xmax - xmin,
-                          -zmin,
-                          color='cornflowerblue'))
+            plt.Rectangle((xmin, zmin), xmax - xmin, -zmin, color="cornflowerblue")
+        )
 
-        if legend != ['', ''] and PlotColors is False:
+        if legend != ["", ""] and PlotColors is False:
             plt.legend(loc=4)
 
-        self.__save_or_plot_animation__(plt.gcf(),
-                                        plot_timestep,
-                                        filename,
-                                        x.shape[1],
-                                        fps,
-                                        interval=150,
-                                        blit=False)
+        self.__save_or_plot_animation__(
+            plt.gcf(),
+            plot_timestep,
+            filename,
+            x.shape[1],
+            fps,
+            interval=150,
+            blit=False,
+        )
 
-        logger.info('Time to make animation: %s' %
-                    (datetime.now() - start_time))
+        logger.info("Time to make animation: %s" % (datetime.now() - start_time))
 
     def _get_comparison_xy_for_plots(self, compare):
         if not type(compare) is list:
@@ -3207,69 +3393,75 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 # Other is given as an OpenDrift object
                 other = comp
 
-            lonmin = np.minimum(lonmin, np.nanmin(other.history['lon']))
-            lonmax = np.maximum(lonmax, np.nanmax(other.history['lon']))
-            latmin = np.minimum(latmin, np.nanmin(other.history['lat']))
-            latmax = np.maximum(latmax, np.nanmax(other.history['lat']))
+            lonmin = np.minimum(lonmin, np.nanmin(other.history["lon"]))
+            lonmax = np.maximum(lonmax, np.nanmax(other.history["lon"]))
+            latmin = np.minimum(latmin, np.nanmin(other.history["lat"]))
+            latmax = np.maximum(latmax, np.nanmax(other.history["lat"]))
 
             # Find map coordinates of comparison simulations
-            cd['x_other'], cd['y_other'] = \
-                (other.history['lon'].copy(), other.history['lat'].copy())
-            cd['x_other_deactive'], cd['y_other_deactive'] = \
-                (other.elements_deactivated.lon.copy(),
-                    other.elements_deactivated.lat.copy())
-            cd['firstlast'] = np.ma.notmasked_edges(cd['x_other'], axis=1)
-            cd['index_of_last_other'] = cd['firstlast'][1][1]
-            cd['index_of_last_deactivated_other'] = \
-                cd['index_of_last_other'][other.elements_deactivated.ID-1]
+            cd["x_other"], cd["y_other"] = (
+                other.history["lon"].copy(),
+                other.history["lat"].copy(),
+            )
+            cd["x_other_deactive"], cd["y_other_deactive"] = (
+                other.elements_deactivated.lon.copy(),
+                other.elements_deactivated.lat.copy(),
+            )
+            cd["firstlast"] = np.ma.notmasked_edges(cd["x_other"], axis=1)
+            cd["index_of_last_other"] = cd["firstlast"][1][1]
+            cd["index_of_last_deactivated_other"] = cd["index_of_last_other"][
+                other.elements_deactivated.ID - 1
+            ]
 
         compare_args = {
-            'compare_lonmin': lonmin,
-            'compare_lonmax': lonmax,
-            'compare_latmin': latmin,
-            'compare_latmax': latmax
+            "compare_lonmin": lonmin,
+            "compare_lonmax": lonmax,
+            "compare_latmin": latmin,
+            "compare_latmax": latmax,
         }
 
         return compare_list, compare_args
 
-    def plot(self,
-             background=None,
-             buffer=.2,
-             corners=None,
-             linecolor=None,
-             filename=None,
-             show=True,
-             vmin=None,
-             vmax=None,
-             compare=None,
-             cmap='jet',
-             lvmin=None,
-             lvmax=None,
-             skip=None,
-             scale=None,
-             show_scalar=True,
-             contourlines=False,
-             drifter=None,
-             colorbar=True,
-             linewidth=1,
-             lcs=None,
-             show_elements=True,
-             show_trajectories=True,
-             show_initial=True,
-             density_pixelsize_m=1000,
-             lalpha=None,
-             bgalpha=1,
-             clabel=None,
-             surface_color=None,
-             submerged_color=None,
-             markersize=20,
-             title='auto',
-             legend=True,
-             legend_loc='best',
-             lscale=None,
-             fast=False,
-             hide_landmask=False,
-             **kwargs):
+    def plot(
+        self,
+        background=None,
+        buffer=0.2,
+        corners=None,
+        linecolor=None,
+        filename=None,
+        show=True,
+        vmin=None,
+        vmax=None,
+        compare=None,
+        cmap="jet",
+        lvmin=None,
+        lvmax=None,
+        skip=None,
+        scale=None,
+        show_scalar=True,
+        contourlines=False,
+        drifter=None,
+        colorbar=True,
+        linewidth=1,
+        lcs=None,
+        show_elements=True,
+        show_trajectories=True,
+        show_initial=True,
+        density_pixelsize_m=1000,
+        lalpha=None,
+        bgalpha=1,
+        clabel=None,
+        surface_color=None,
+        submerged_color=None,
+        markersize=20,
+        title="auto",
+        legend=True,
+        legend_loc="best",
+        lscale=None,
+        fast=False,
+        hide_landmask=False,
+        **kwargs,
+    ):
         """Basic built-in plotting function intended for developing/debugging.
 
         Plots trajectories of all particles.
@@ -3307,9 +3499,12 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         mappable = None
 
-        if self.history is not None and self.num_elements_total(
-        ) == 0 and not hasattr(self, 'ds'):
-            raise ValueError('Please run simulation before animating')
+        if (
+            self.history is not None
+            and self.num_elements_total() == 0
+            and not hasattr(self, "ds")
+        ):
+            raise ValueError("Please run simulation before animating")
 
         start_time = datetime.now()
 
@@ -3321,31 +3516,33 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         if drifter is not None:
             # Extend map coverage to cover provided trajectory
             # TODO: drifter should be list of dictionaries
-            ttime = np.array(drifter['time'])
+            ttime = np.array(drifter["time"])
             i = np.where((ttime >= self.start_time) & (ttime <= self.time))[0]
-            drifter['lon'] = np.atleast_1d(drifter['lon'])
-            drifter['lat'] = np.atleast_1d(drifter['lat'])
-            tlonmin = drifter['lon'][i].min()
-            tlonmax = drifter['lon'][i].max()
-            tlatmin = drifter['lat'][i].min()
-            tlatmax = drifter['lat'][i].max()
-            if 'compare_lonmin' not in kwargs:
-                kwargs['compare_lonmin'] = tlonmin
-                kwargs['compare_lonmax'] = tlonmax
-                kwargs['compare_latmin'] = tlatmin
-                kwargs['compare_latmax'] = tlatmax
+            drifter["lon"] = np.atleast_1d(drifter["lon"])
+            drifter["lat"] = np.atleast_1d(drifter["lat"])
+            tlonmin = drifter["lon"][i].min()
+            tlonmax = drifter["lon"][i].max()
+            tlatmin = drifter["lat"][i].min()
+            tlatmax = drifter["lat"][i].max()
+            if "compare_lonmin" not in kwargs:
+                kwargs["compare_lonmin"] = tlonmin
+                kwargs["compare_lonmax"] = tlonmax
+                kwargs["compare_latmin"] = tlatmin
+                kwargs["compare_latmax"] = tlatmax
             else:
-                kwargs['compare_lonmin'] = np.minimum(kwargs['compare_lonmin'],
-                                                      tlonmin)
-                kwargs['compare_lonmax'] = np.maximum(kwargs['compare_lonmax'],
-                                                      tlonmax)
-                kwargs['compare_latmin'] = np.minimum(kwargs['compare_latmin'],
-                                                      tlatmin)
-                kwargs['compare_latmax'] = np.maximum(kwargs['compare_latmax'],
-                                                      tlatmax)
+                kwargs["compare_lonmin"] = np.minimum(kwargs["compare_lonmin"], tlonmin)
+                kwargs["compare_lonmax"] = np.maximum(kwargs["compare_lonmax"], tlonmax)
+                kwargs["compare_latmin"] = np.minimum(kwargs["compare_latmin"], tlatmin)
+                kwargs["compare_latmax"] = np.maximum(kwargs["compare_latmax"], tlatmax)
 
-        fig, ax, crs, x, y, index_of_first, index_of_last = \
-            self.set_up_map(buffer=buffer, corners=corners, lscale=lscale, fast=fast, hide_landmask=hide_landmask, **kwargs)
+        fig, ax, crs, x, y, index_of_first, index_of_last = self.set_up_map(
+            buffer=buffer,
+            corners=corners,
+            lscale=lscale,
+            fast=fast,
+            hide_landmask=hide_landmask,
+            **kwargs,
+        )
 
         # x, y are longitude, latitude -> i.e. in a PlateCarree CRS
         gcrs = ccrs.PlateCarree(globe=crs.globe)
@@ -3356,8 +3553,9 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         if lalpha is None:
             min_alpha = 0.1
             max_elements = 5000.0
-            alpha = min_alpha**(2 * (self.num_elements_total() - 1) /
-                                (max_elements - 1))
+            alpha = min_alpha ** (
+                2 * (self.num_elements_total() - 1) / (max_elements - 1)
+            )
             alpha = np.max((min_alpha, alpha))
         else:
             alpha = lalpha  #  provided transparency of trajectories
@@ -3366,164 +3564,186 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         if self.history is not None and linewidth != 0 and show_trajectories is True:
             # Plot trajectories
             from matplotlib.colors import is_color_like
+
             if linecolor is None or is_color_like(linecolor) is True:
                 if is_color_like(linecolor):
                     linecolor = linecolor
                 else:
-                    linecolor = 'gray'
+                    linecolor = "gray"
                 if compare is not None and legend is not None:
                     if legend is True:
-                        if hasattr(compare, 'len'):
+                        if hasattr(compare, "len"):
                             numleg = len(compare)
                         else:
                             numleg = 2
-                        legend = [
-                            'Simulation %d' % (i + 1) for i in range(numleg)
-                        ]
-                    ax.plot(x[:, 0],
-                            y[:, 0],
-                            color=linecolor,
-                            alpha=alpha,
-                            label=legend[0],
-                            linewidth=linewidth,
-                            transform=gcrs)
-                    ax.plot(x,
-                            y,
-                            color=linecolor,
-                            alpha=alpha,
-                            label='_nolegend_',
-                            linewidth=linewidth,
-                            transform=gcrs)
+                        legend = ["Simulation %d" % (i + 1) for i in range(numleg)]
+                    ax.plot(
+                        x[:, 0],
+                        y[:, 0],
+                        color=linecolor,
+                        alpha=alpha,
+                        label=legend[0],
+                        linewidth=linewidth,
+                        transform=gcrs,
+                    )
+                    ax.plot(
+                        x,
+                        y,
+                        color=linecolor,
+                        alpha=alpha,
+                        label="_nolegend_",
+                        linewidth=linewidth,
+                        transform=gcrs,
+                    )
                 else:
-                    ax.plot(x,
-                            y,
-                            color=linecolor,
-                            alpha=alpha,
-                            linewidth=linewidth,
-                            transform=gcrs)
+                    ax.plot(
+                        x,
+                        y,
+                        color=linecolor,
+                        alpha=alpha,
+                        linewidth=linewidth,
+                        transform=gcrs,
+                    )
             else:
-                #colorbar = True
+                # colorbar = True
                 # Color lines according to given parameter
                 try:
                     if isinstance(linecolor, str):
                         param = self.history[linecolor]
-                    elif hasattr(linecolor, '__len__'):
+                    elif hasattr(linecolor, "__len__"):
                         param = np.tile(linecolor, (self.steps_output, 1)).T
                     else:
                         param = linecolor
                 except:
                     raise ValueError(
-                        'Available parameters to be used for linecolors: ' +
-                        str(self.history.dtype.fields))
+                        "Available parameters to be used for linecolors: "
+                        + str(self.history.dtype.fields)
+                    )
                 from matplotlib.collections import LineCollection
+
                 for i in range(x.shape[1]):
                     vind = np.arange(index_of_first[i], index_of_last[i] + 1)
-                    points = np.array([x[vind, i].T,
-                                       y[vind, i].T]).T.reshape(-1, 1, 2)
-                    segments = np.concatenate([points[:-1], points[1:]],
-                                              axis=1)
+                    points = np.array([x[vind, i].T, y[vind, i].T]).T.reshape(-1, 1, 2)
+                    segments = np.concatenate([points[:-1], points[1:]], axis=1)
                     if lvmin is None:
                         lvmin = param.min()
                         lvmax = param.max()
                     lc = LineCollection(
                         segments,
-                        #cmap=plt.get_cmap('Spectral'),
+                        # cmap=plt.get_cmap('Spectral'),
                         cmap=cmap,
                         norm=plt.Normalize(lvmin, lvmax),
-                        transform=gcrs)
-                    #lc.set_linewidth(3)
+                        transform=gcrs,
+                    )
+                    # lc.set_linewidth(3)
                     lc.set_array(param.T[vind, i])
                     mappable = ax.add_collection(lc)
-                #axcb = fig.colorbar(lc, ax = ax, orientation = 'horizontal')
-                #try:  # Add unit to colorbar if available
+                # axcb = fig.colorbar(lc, ax = ax, orientation = 'horizontal')
+                # try:  # Add unit to colorbar if available
                 #    colorbarstring = linecolor + '  [%s]' % \
                 #        (self.history_metadata[linecolor]['units'])
-                #except:
+                # except:
                 #    colorbarstring = linecolor
                 ##axcb.set_label(colorbarstring)
-                #axcb.set_label(colorbarstring, size=14)
-                #axcb.ax.tick_params(labelsize=14)
+                # axcb.set_label(colorbarstring, size=14)
+                # axcb.ax.tick_params(labelsize=14)
 
         if compare is None:
-            label_initial = 'initial (%i)' % x.shape[1]
-            label_active = 'active (%i)' % (x.shape[1] -
-                                            self.num_elements_deactivated())
-            color_initial = self.status_colors['initial']
-            color_active = self.status_colors['active']
+            label_initial = "initial (%i)" % x.shape[1]
+            label_active = "active (%i)" % (
+                x.shape[1] - self.num_elements_deactivated()
+            )
+            color_initial = self.status_colors["initial"]
+            color_active = self.status_colors["active"]
         else:
             label_initial = None
             label_active = None
-            color_initial = 'gray'
-            color_active = 'gray'
+            color_initial = "gray"
+            color_active = "gray"
         if show_elements is True:
             if show_initial is True:
-                ax.scatter(x[index_of_first, range(x.shape[1])],
-                           y[index_of_first, range(x.shape[1])],
-                           s=markersize,
-                           zorder=10,
-                           edgecolor=markercolor,
-                           linewidths=.2,
-                           c=color_initial,
-                           label=label_initial,
-                           transform=gcrs)
+                ax.scatter(
+                    x[index_of_first, range(x.shape[1])],
+                    y[index_of_first, range(x.shape[1])],
+                    s=markersize,
+                    zorder=10,
+                    edgecolor=markercolor,
+                    linewidths=0.2,
+                    c=color_initial,
+                    label=label_initial,
+                    transform=gcrs,
+                )
             if surface_color is not None:
                 color_active = surface_color
-                label_active = 'surface'
-            ax.scatter(x[index_of_last, range(x.shape[1])],
-                       y[index_of_last, range(x.shape[1])],
-                       s=markersize,
-                       zorder=3,
-                       edgecolor=markercolor,
-                       linewidths=.2,
-                       c=color_active,
-                       label=label_active,
-                       transform=gcrs)
-            #if submerged_color is not None:
+                label_active = "surface"
+            ax.scatter(
+                x[index_of_last, range(x.shape[1])],
+                y[index_of_last, range(x.shape[1])],
+                s=markersize,
+                zorder=3,
+                edgecolor=markercolor,
+                linewidths=0.2,
+                c=color_active,
+                label=label_active,
+                transform=gcrs,
+            )
+            # if submerged_color is not None:
             #    map.scatter(x[range(x.shape[0]), index_of_last],
             #                y[range(x.shape[0]), index_of_last], s=markersize,
             #                zorder=3, edgecolor=markercolor, linewidths=.2,
             #                c=submerged_color, label='submerged')
 
-            x_deactivated, y_deactivated = (self.elements_deactivated.lon,
-                                            self.elements_deactivated.lat)
+            x_deactivated, y_deactivated = (
+                self.elements_deactivated.lon,
+                self.elements_deactivated.lat,
+            )
             # Plot deactivated elements, labeled by deactivation reason
             for statusnum, status in enumerate(self.status_categories):
-                if status == 'active':
+                if status == "active":
                     continue  # plotted above
                 if status not in self.status_colors:
                     # If no color specified, pick an unused one
                     for color in [
-                            'red', 'blue', 'green', 'black', 'gray', 'cyan',
-                            'DarkSeaGreen', 'brown'
+                        "red",
+                        "blue",
+                        "green",
+                        "black",
+                        "gray",
+                        "cyan",
+                        "DarkSeaGreen",
+                        "brown",
                     ]:
                         if color not in self.status_colors.values():
                             self.status_colors[status] = color
                             break
-                indices = np.where(
-                    self.elements_deactivated.status == statusnum)
+                indices = np.where(self.elements_deactivated.status == statusnum)
                 if len(indices[0]) > 0:
-                    if (status == 'seeded_on_land'
-                            or status == 'seeded_at_nodata_position'):
+                    if (
+                        status == "seeded_on_land"
+                        or status == "seeded_at_nodata_position"
+                    ):
                         zorder = 11
                     else:
                         zorder = 3
                     if compare is not None:
                         legstr = None
                     else:
-                        legstr = '%s (%i)' % (status, len(indices[0]))
+                        legstr = "%s (%i)" % (status, len(indices[0]))
                     if compare is None:
                         color_status = self.status_colors[status]
                     else:
-                        color_status = 'gray'
-                    ax.scatter(x_deactivated[indices],
-                               y_deactivated[indices],
-                               s=markersize,
-                               zorder=zorder,
-                               edgecolor=markercolor,
-                               linewidths=.1,
-                               c=color_status,
-                               label=legstr,
-                               transform=gcrs)
+                        color_status = "gray"
+                    ax.scatter(
+                        x_deactivated[indices],
+                        y_deactivated[indices],
+                        s=markersize,
+                        zorder=zorder,
+                        edgecolor=markercolor,
+                        linewidths=0.1,
+                        c=color_status,
+                        label=legstr,
+                        transform=gcrs,
+                    )
 
         if compare is not None:
             for i, c in enumerate(cd):
@@ -3531,94 +3751,108 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                     legstr = legend[i + 1]
                 else:
                     legstr = None
-                ax.plot(c['x_other'].T[:, 0],
-                        c['y_other'].T[:, 0],
-                        color=self.plot_comparison_colors[i + 1],
-                        linestyle='-',
-                        label=legstr,
-                        linewidth=linewidth,
-                        transform=gcrs)
-                ax.plot(c['x_other'].T,
-                        c['y_other'].T,
-                        color=self.plot_comparison_colors[i + 1],
-                        linestyle='-',
-                        label='_nolegend_',
-                        linewidth=linewidth,
-                        transform=gcrs)
-                ax.scatter(c['x_other'][range(c['x_other'].shape[0]),
-                                        c['index_of_last_other']],
-                           c['y_other'][range(c['y_other'].shape[0]),
-                                        c['index_of_last_other']],
-                           s=markersize,
-                           zorder=3,
-                           edgecolor=markercolor,
-                           linewidths=.2,
-                           c=self.plot_comparison_colors[i + 1],
-                           transform=gcrs)
+                ax.plot(
+                    c["x_other"].T[:, 0],
+                    c["y_other"].T[:, 0],
+                    color=self.plot_comparison_colors[i + 1],
+                    linestyle="-",
+                    label=legstr,
+                    linewidth=linewidth,
+                    transform=gcrs,
+                )
+                ax.plot(
+                    c["x_other"].T,
+                    c["y_other"].T,
+                    color=self.plot_comparison_colors[i + 1],
+                    linestyle="-",
+                    label="_nolegend_",
+                    linewidth=linewidth,
+                    transform=gcrs,
+                )
+                ax.scatter(
+                    c["x_other"][
+                        range(c["x_other"].shape[0]), c["index_of_last_other"]
+                    ],
+                    c["y_other"][
+                        range(c["y_other"].shape[0]), c["index_of_last_other"]
+                    ],
+                    s=markersize,
+                    zorder=3,
+                    edgecolor=markercolor,
+                    linewidths=0.2,
+                    c=self.plot_comparison_colors[i + 1],
+                    transform=gcrs,
+                )
 
         if background is not None:
-            if hasattr(self, 'time'):
+            if hasattr(self, "time"):
                 time = self.time - self.time_step_output
             else:
                 time = None
             if isinstance(background, xr.DataArray):
-                map_x = background.coords['lon_bin']
-                map_y = background.coords['lat_bin']
+                map_x = background.coords["lon_bin"]
+                map_y = background.coords["lat_bin"]
                 scalar = background
                 map_y, map_x = np.meshgrid(map_y, map_x)
-            elif background == 'residence':
+            elif background == "residence":
                 scalar, lon_res, lat_res = self.get_residence_time(
-                    pixelsize_m=density_pixelsize_m)
+                    pixelsize_m=density_pixelsize_m
+                )
                 scalar[scalar == 0] = np.nan
                 lon_res, lat_res = np.meshgrid(lon_res[0:-1], lat_res[0:-1])
                 lon_res = lon_res.T
                 lat_res = lat_res.T
                 map_x, map_y = (lon_res, lat_res)
             else:
-                map_x, map_y, scalar, u_component, v_component = \
+                map_x, map_y, scalar, u_component, v_component = (
                     self.get_map_background(ax, background, crs, time=time)
-                #self.time_step_output)
+                )
+                # self.time_step_output)
 
             if show_scalar is True:
                 if contourlines is False:
                     scalar = np.ma.masked_invalid(scalar)
-                    mappable = ax.pcolormesh(map_x,
-                                             map_y,
-                                             scalar,
-                                             alpha=bgalpha,
-                                             zorder=1,
-                                             vmin=vmin,
-                                             vmax=vmax,
-                                             cmap=cmap,
-                                             transform=gcrs)
+                    mappable = ax.pcolormesh(
+                        map_x,
+                        map_y,
+                        scalar,
+                        alpha=bgalpha,
+                        zorder=1,
+                        vmin=vmin,
+                        vmax=vmax,
+                        cmap=cmap,
+                        transform=gcrs,
+                    )
                 else:
                     if contourlines is True:
-                        CS = ax.contour(map_x,
-                                        map_y,
-                                        scalar,
-                                        colors='gray',
-                                        transform=gcrs)
+                        CS = ax.contour(
+                            map_x, map_y, scalar, colors="gray", transform=gcrs
+                        )
                     else:
                         # contourlines is an array of values
-                        CS = ax.contour(map_x,
-                                        map_y,
-                                        scalar,
-                                        contourlines,
-                                        colors='gray',
-                                        transform=gcrs)
-                    plt.clabel(CS, fmt='%g')
+                        CS = ax.contour(
+                            map_x,
+                            map_y,
+                            scalar,
+                            contourlines,
+                            colors="gray",
+                            transform=gcrs,
+                        )
+                    plt.clabel(CS, fmt="%g")
 
         if mappable is not None and colorbar is True:
-            cb = fig.colorbar(mappable,
-                              orientation='horizontal',
-                              pad=.05,
-                              aspect=30,
-                              shrink=.8,
-                              drawedges=False)
+            cb = fig.colorbar(
+                mappable,
+                orientation="horizontal",
+                pad=0.05,
+                aspect=30,
+                shrink=0.8,
+                drawedges=False,
+            )
             # TODO: need better control of colorbar content
             if clabel is not None:
                 cb.set_label(clabel)
-            elif isinstance(linecolor, str) and linecolor != 'gray':
+            elif isinstance(linecolor, str) and linecolor != "gray":
                 cb.set_label(str(linecolor))
             if background is not None and clabel is None:
                 if isinstance(background, xr.DataArray):
@@ -3627,40 +3861,51 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                     cb.set_label(str(background))
 
         if type(background) is list:
-            ax.quiver(map_x[::skip, ::skip],
-                      map_y[::skip, ::skip],
-                      u_component[::skip, ::skip],
-                      v_component[::skip, ::skip],
-                      scale=scale,
-                      transform=gcrs,
-                      zorder=1)
+            ax.quiver(
+                map_x[::skip, ::skip],
+                map_y[::skip, ::skip],
+                u_component[::skip, ::skip],
+                v_component[::skip, ::skip],
+                scale=scale,
+                transform=gcrs,
+                zorder=1,
+            )
 
         if lcs is not None:
-            map_x_lcs, map_y_lcs = (lcs['lon'], lcs['lat'])
-            ax.pcolormesh(map_x_lcs,
-                          map_y_lcs,
-                          lcs['ALCS'][0, :, :],
-                          alpha=1,
-                          vmin=vmin,
-                          vmax=vmax,
-                          zorder=0,
-                          cmap=cmap,
-                          transform=gcrs)
+            map_x_lcs, map_y_lcs = (lcs["lon"], lcs["lat"])
+            ax.pcolormesh(
+                map_x_lcs,
+                map_y_lcs,
+                lcs["ALCS"][0, :, :],
+                alpha=1,
+                vmin=vmin,
+                vmax=vmax,
+                zorder=0,
+                cmap=cmap,
+                transform=gcrs,
+            )
 
         if title is not None:
-            if title == 'auto':
-                if hasattr(self, 'time'):
-                    plt.title('%s\n%s to %s UTC (%i steps)' %
-                              (self._figure_title(),
-                               self.start_time.strftime('%Y-%m-%d %H:%M'),
-                               self.time.strftime('%Y-%m-%d %H:%M'),
-                               self.steps_output))
+            if title == "auto":
+                if hasattr(self, "time"):
+                    plt.title(
+                        "%s\n%s to %s UTC (%i steps)"
+                        % (
+                            self._figure_title(),
+                            self.start_time.strftime("%Y-%m-%d %H:%M"),
+                            self.time.strftime("%Y-%m-%d %H:%M"),
+                            self.steps_output,
+                        )
+                    )
                 else:
                     plt.title(
-                        '%s\n%i elements seeded at %s UTC' %
-                        (self._figure_title(), self.num_elements_scheduled(),
-                         self.elements_scheduled_time[0].strftime(
-                             '%Y-%m-%d %H:%M')))
+                        "%s\n%i elements seeded at %s UTC"
+                        % (
+                            self._figure_title(),
+                            self.num_elements_scheduled(),
+                            self.elements_scheduled_time[0].strftime("%Y-%m-%d %H:%M"),
+                        )
+                    )
             else:
                 plt.title(title)
 
@@ -3672,16 +3917,15 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             if legend is not None and len(handles) > 0:
                 plt.legend(loc=legend_loc, markerscale=2)
         except Exception as e:
-            logger.warning('Cannot plot legend, due to bug in matplotlib:')
+            logger.warning("Cannot plot legend, due to bug in matplotlib:")
             logger.warning(traceback.format_exc())
 
-        #plt.gca().tick_params(labelsize=14)
+        # plt.gca().tick_params(labelsize=14)
 
-        #fig.canvas.draw()
+        # fig.canvas.draw()
         if filename is not None:
             plt.savefig(filename)
-            logger.info('Time to make plot: ' +
-                        str(datetime.now() - start_time))
+            logger.info("Time to make plot: " + str(datetime.now() - start_time))
         else:
             if show is True:
                 plt.show()
@@ -3693,32 +3937,34 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
     def _figure_title(self):
         if self._substance_name() is None:
-            return 'OpenDrift - ' + type(self).__name__
+            return "OpenDrift - " + type(self).__name__
         else:
-            return 'OpenDrift - ' + type(
-                self).__name__ + ' (%s)' % self._substance_name()
+            return (
+                "OpenDrift - " + type(self).__name__ + " (%s)" % self._substance_name()
+            )
 
     def _plot_drifter(self, ax, gcrs, drifter):
-        '''Plot provided trajectory along with simulated'''
-        time = drifter['time']
+        """Plot provided trajectory along with simulated"""
+        time = drifter["time"]
         time = np.array(time)
         i = np.where((time >= self.start_time) & (time <= self.time))[0]
-        x, y = (np.atleast_1d(drifter['lon'])[i],
-                np.atleast_1d(drifter['lat'])[i])
-        dlabel = drifter['label'] if 'label' in drifter else 'Drifter'
-        dcolor = drifter['color'] if 'color' in drifter else 'r'
-        dlinewidth = drifter['linewidth'] if 'linewidth' in drifter else 2
-        dzorder = drifter['zorder'] if 'zorder' in drifter else 10
+        x, y = (np.atleast_1d(drifter["lon"])[i], np.atleast_1d(drifter["lat"])[i])
+        dlabel = drifter["label"] if "label" in drifter else "Drifter"
+        dcolor = drifter["color"] if "color" in drifter else "r"
+        dlinewidth = drifter["linewidth"] if "linewidth" in drifter else 2
+        dzorder = drifter["zorder"] if "zorder" in drifter else 10
 
-        ax.plot(x,
-                y,
-                linewidth=dlinewidth,
-                color=dcolor,
-                transform=gcrs,
-                label=dlabel,
-                zorder=dzorder)
-        ax.plot(x[0], y[0], 'ok', transform=gcrs)
-        ax.plot(x[-1], y[-1], 'xk', transform=gcrs)
+        ax.plot(
+            x,
+            y,
+            linewidth=dlinewidth,
+            color=dcolor,
+            transform=gcrs,
+            label=dlabel,
+            zorder=dzorder,
+        )
+        ax.plot(x[0], y[0], "ok", transform=gcrs)
+        ax.plot(x[-1], y[-1], "xk", transform=gcrs)
 
     def get_map_background(self, ax, background, crs, time=None):
         # Get background field for plotting on map or animation
@@ -3730,20 +3976,21 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         for readerName in self.env.readers:
             reader = self.env.readers[readerName]
             if variable in reader.variables:
-                if time is None or reader.start_time is None or (
-                        time >= reader.start_time
-                        and time <= reader.end_time) or (reader.always_valid
-                                                         is True):
+                if (
+                    time is None
+                    or reader.start_time is None
+                    or (time >= reader.start_time and time <= reader.end_time)
+                    or (reader.always_valid is True)
+                ):
                     break
         if time is None:
-            if hasattr(self, 'elements_scheduled_time'):
+            if hasattr(self, "elements_scheduled_time"):
                 # Using time of first seeded element
                 time = self.elements_scheduled_time[0]
 
         # Get reader coordinates covering given map area
         axisproj = pyproj.Proj(ax.projection.proj4_params)
-        xmin, xmax, ymin, ymax = ax.get_extent(
-            ccrs.PlateCarree(globe=crs.globe))
+        xmin, xmax, ymin, ymax = ax.get_extent(ccrs.PlateCarree(globe=crs.globe))
         cornerlons = np.array([xmin, xmin, xmax, xmax])
         cornerlats = np.array([ymin, ymax, ymin, ymax])
         reader_x, reader_y = reader.lonlat2xy(cornerlons, cornerlats)
@@ -3756,20 +4003,26 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             reader_y = np.linspace(reader_y.min(), reader_y.max(), 10)
 
         data = reader.get_variables(background, time, reader_x, reader_y, None)
-        reader_x, reader_y = np.meshgrid(data['x'], data['y'])
+        reader_x, reader_y = np.meshgrid(data["x"], data["y"])
         if type(background) is list:  # Ensemble reader, using first member
             u_component = data[background[0]]
             v_component = data[background[1]]
             if isinstance(u_component, list):
                 u_component = u_component[0]
                 v_component = v_component[0]
-            with np.errstate(invalid='ignore'):
+            with np.errstate(invalid="ignore"):
                 scalar = np.sqrt(u_component**2 + v_component**2)
             # NB: rotation not completed!
             u_component, v_component = reader.rotate_vectors(
-                reader_x, reader_y, u_component, v_component, reader.proj,
-                ccrs.PlateCarree(globe=ccrs.Globe(datum='WGS84',
-                                                  ellipse='WGS84')).proj4_init)
+                reader_x,
+                reader_y,
+                u_component,
+                v_component,
+                reader.proj,
+                ccrs.PlateCarree(
+                    globe=ccrs.Globe(datum="WGS84", ellipse="WGS84")
+                ).proj4_init,
+            )
         else:
             scalar = data[background]
             if isinstance(scalar, list):  # Ensemble reader, using first member
@@ -3802,57 +4055,69 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
     def get_histogram(self, pixelsize_m, **kwargs):
         from xhistogram.xarray import histogram
+
         lonbin, latbin = self.get_lonlat_bins(pixelsize_m)
         max_om = int(self.ds.origin_marker.max().compute().values)
         origin_marker = range(max_om + 1)
-        if 'weights' in kwargs and kwargs['weights'] is not None and kwargs[
-                'weights'].ndim < 2:
-            kwargs['weights'] = xr.DataArray(
-                kwargs['weights'],
-                dims=['trajectory'],
-                coords={'trajectory': self.ds.coords['trajectory']})
+        if (
+            "weights" in kwargs
+            and kwargs["weights"] is not None
+            and kwargs["weights"].ndim < 2
+        ):
+            kwargs["weights"] = xr.DataArray(
+                kwargs["weights"],
+                dims=["trajectory"],
+                coords={"trajectory": self.ds.coords["trajectory"]},
+            )
         # Xarray Dataset to store histogram per origin_marker
-        h_om = xr.DataArray(np.zeros(
-            (len(self.ds.coords['time']), len(lonbin) - 1, len(latbin) - 1,
-             max_om + 1)),
-                            name='density_origin_marker',
-                            dims=('time', 'lon_bin', 'lat_bin',
-                                  'origin_marker'))
-        h_om.coords['time'] = self.ds.coords['time']
-        h_om.coords['origin_marker'] = origin_marker
+        h_om = xr.DataArray(
+            np.zeros(
+                (
+                    len(self.ds.coords["time"]),
+                    len(lonbin) - 1,
+                    len(latbin) - 1,
+                    max_om + 1,
+                )
+            ),
+            name="density_origin_marker",
+            dims=("time", "lon_bin", "lat_bin", "origin_marker"),
+        )
+        h_om.coords["time"] = self.ds.coords["time"]
+        h_om.coords["origin_marker"] = origin_marker
 
         for om in origin_marker:
-            logger.info('\tcalculating for origin_marker %s...' % om)
-            h = histogram(self.ds.lon.where(self.ds.origin_marker == om),
-                          self.ds.lat.where(self.ds.origin_marker == om),
-                          bins=[lonbin, latbin],
-                          dim=['trajectory'],
-                          **kwargs)
+            logger.info("\tcalculating for origin_marker %s..." % om)
+            h = histogram(
+                self.ds.lon.where(self.ds.origin_marker == om),
+                self.ds.lat.where(self.ds.origin_marker == om),
+                bins=[lonbin, latbin],
+                dim=["trajectory"],
+                **kwargs,
+            )
             if om == 0:
-                h_om.coords['lon_bin'] = h.coords['lon_bin']
-                h_om.coords['lat_bin'] = h.coords['lat_bin']
-            h_om[:, :, :, om] = h  #.copy()
+                h_om.coords["lon_bin"] = h.coords["lon_bin"]
+                h_om.coords["lat_bin"] = h.coords["lat_bin"]
+            h_om[:, :, :, om] = h  # .copy()
         return h_om
 
     def get_density_array(self, pixelsize_m, weight=None):
-        lon = self.get_property('lon')[0]
-        lat = self.get_property('lat')[0]
+        lon = self.get_property("lon")[0]
+        lat = self.get_property("lat")[0]
         times = self.get_time_array()[0]
         deltalat = pixelsize_m / 111000.0  # m to degrees
-        deltalon = deltalat / np.cos(
-            np.radians((np.nanmin(lat) + np.nanmax(lat)) / 2))
+        deltalon = deltalat / np.cos(np.radians((np.nanmin(lat) + np.nanmax(lat)) / 2))
         lat_array = np.arange(
-            np.nanmin(lat) - deltalat,
-            np.nanmax(lat) + deltalat, deltalat)
+            np.nanmin(lat) - deltalat, np.nanmax(lat) + deltalat, deltalat
+        )
         lon_array = np.arange(
-            np.nanmin(lon) - deltalat,
-            np.nanmax(lon) + deltalon, deltalon)
+            np.nanmin(lon) - deltalat, np.nanmax(lon) + deltalon, deltalon
+        )
         bins = (lon_array, lat_array)
-        z = self.get_property('z')[0]
+        z = self.get_property("z")[0]
         if weight is not None:
             weight_array = self.get_property(weight)[0]
 
-        status = self.get_property('status')[0]
+        status = self.get_property("status")[0]
         lon_submerged = lon.copy()
         lat_submerged = lat.copy()
         lon_stranded = lon.copy()
@@ -3861,12 +4126,13 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         lat_submerged[z >= 0] = 1000
         lon[z < 0] = 1000
         lat[z < 0] = 1000
-        H = np.zeros((len(times), len(lon_array) - 1,
-                      len(lat_array) - 1))  #.astype(int)
+        H = np.zeros(
+            (len(times), len(lon_array) - 1, len(lat_array) - 1)
+        )  # .astype(int)
         H_submerged = H.copy()
         H_stranded = H.copy()
         try:
-            strandnum = self.status_categories.index('stranded')
+            strandnum = self.status_categories.index("stranded")
             lon_stranded[status != strandnum] = 1000
             lat_stranded[status != strandnum] = 1000
             contains_stranded = True
@@ -3878,45 +4144,47 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 weights = weight_array[i, :]
             else:
                 weights = None
-            H[i,:,:], dummy, dummy = \
-                np.histogram2d(lon[i,:], lat[i,:],
-                               weights=weights, bins=bins)
-            H_submerged[i,:,:], dummy, dummy = \
-                np.histogram2d(lon_submerged[i,:], lat_submerged[i,:],
-                               weights=weights, bins=bins)
+            H[i, :, :], dummy, dummy = np.histogram2d(
+                lon[i, :], lat[i, :], weights=weights, bins=bins
+            )
+            H_submerged[i, :, :], dummy, dummy = np.histogram2d(
+                lon_submerged[i, :], lat_submerged[i, :], weights=weights, bins=bins
+            )
             if contains_stranded is True:
-                H_stranded[i,:,:], dummy, dummy = \
-                np.histogram2d(lon_stranded[i,:], lat_stranded[i,:],
-                               weights=weights, bins=bins)
+                H_stranded[i, :, :], dummy, dummy = np.histogram2d(
+                    lon_stranded[i, :], lat_stranded[i, :], weights=weights, bins=bins
+                )
 
         return H, H_submerged, H_stranded, lon_array, lat_array
 
-    def get_density_array_proj(self,
-                               pixelsize_m,
-                               density_proj=None,
-                               llcrnrlon=None,
-                               llcrnrlat=None,
-                               urcrnrlon=None,
-                               urcrnrlat=None,
-                               weight=None):
+    def get_density_array_proj(
+        self,
+        pixelsize_m,
+        density_proj=None,
+        llcrnrlon=None,
+        llcrnrlat=None,
+        urcrnrlon=None,
+        urcrnrlat=None,
+        weight=None,
+    ):
         #
         # TODO: should be merged with get_density_array
         # KFD Jan 2021
         #
-        lon = self.get_property('lon')[0]
-        lat = self.get_property('lat')[0]
+        lon = self.get_property("lon")[0]
+        lat = self.get_property("lat")[0]
         times = self.get_time_array()[0]
-        #deltalat = pixelsize_m/111000.0  # m to degrees
-        #deltalon = deltalat/np.cos(np.radians((np.nanmin(lat) +
+        # deltalat = pixelsize_m/111000.0  # m to degrees
+        # deltalon = deltalat/np.cos(np.radians((np.nanmin(lat) +
         #                                       np.nanmax(lat))/2))
-        #lat_array = np.arange(np.nanmin(lat)-deltalat,
+        # lat_array = np.arange(np.nanmin(lat)-deltalat,
         #                      np.nanmax(lat)+deltalat, deltalat)
-        #lon_array = np.arange(np.nanmin(lon)-deltalat,
+        # lon_array = np.arange(np.nanmin(lon)-deltalat,
         #                      np.nanmax(lon)+deltalon, deltalon)
-        #bins=(lon_array, lat_array)
+        # bins=(lon_array, lat_array)
         if density_proj is None:  # add default projection with equal-area property
-            density_proj = pyproj.Proj('+proj=moll +ellps=WGS84 +lon_0=0.0')
-            density_proj = pyproj.Proj('+proj=longlat +a=6371229 +no_defs')
+            density_proj = pyproj.Proj("+proj=moll +ellps=WGS84 +lon_0=0.0")
+            density_proj = pyproj.Proj("+proj=longlat +a=6371229 +no_defs")
 
         # create a grid in the specified projection
         x, y = density_proj(lon, lat)
@@ -3932,20 +4200,20 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         bins = (x_array, y_array)
         outsidex, outsidey = max(x_array) * 1.5, max(y_array) * 1.5
 
-        z = self.get_property('z')[0]
+        z = self.get_property("z")[0]
         if weight is not None:
             weight_array = self.get_property(weight)[0]
 
-        status = self.get_property('status')[0]
-        #lon_submerged = lon.copy()
-        #lat_submerged = lat.copy()
-        #lon_stranded = lon.copy()
-        #lat_stranded = lat.copy()
-        #lon_submerged[z>=0] = 1000
-        #lat_submerged[z>=0] = 1000
-        #lon[z<0] = 1000
-        #lat[z<0] = 1000
-        #H = np.zeros((len(times), len(lon_array) - 1,
+        status = self.get_property("status")[0]
+        # lon_submerged = lon.copy()
+        # lat_submerged = lat.copy()
+        # lon_stranded = lon.copy()
+        # lat_stranded = lat.copy()
+        # lon_submerged[z>=0] = 1000
+        # lat_submerged[z>=0] = 1000
+        # lon[z<0] = 1000
+        # lat[z<0] = 1000
+        # H = np.zeros((len(times), len(lon_array) - 1,
         #              len(lat_array) - 1))#.astype(int)
         x_submerged = x.copy()
         y_submerged = y.copy()
@@ -3955,14 +4223,13 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         y_submerged[z >= 0] = outsidey
         x[z < 0] = outsidex
         y[z < 0] = outsidey
-        H = np.zeros(
-            (len(times), len(x_array) - 1, len(y_array) - 1))  #.astype(int)
+        H = np.zeros((len(times), len(x_array) - 1, len(y_array) - 1))  # .astype(int)
         H_submerged = H.copy()
         H_stranded = H.copy()
         try:
-            strandnum = self.status_categories.index('stranded')
-            #lon_stranded[status!=strandnum] = 1000
-            #lat_stranded[status!=strandnum] = 1000
+            strandnum = self.status_categories.index("stranded")
+            # lon_stranded[status!=strandnum] = 1000
+            # lat_stranded[status!=strandnum] = 1000
             x_stranded[status != strandnum] = outsidex
             y_stranded[status != strandnum] = outsidey
             contains_stranded = True
@@ -3974,16 +4241,16 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 weights = weight_array[i, :]
             else:
                 weights = None
-            H[i,:,:], dummy, dummy = \
-                np.histogram2d(x[i,:], y[i,:],
-                               weights=weights, bins=bins)
-            H_submerged[i,:,:], dummy, dummy = \
-                np.histogram2d(x_submerged[i,:], y_submerged[i,:],
-                               weights=weights, bins=bins)
+            H[i, :, :], dummy, dummy = np.histogram2d(
+                x[i, :], y[i, :], weights=weights, bins=bins
+            )
+            H_submerged[i, :, :], dummy, dummy = np.histogram2d(
+                x_submerged[i, :], y_submerged[i, :], weights=weights, bins=bins
+            )
             if contains_stranded is True:
-                H_stranded[i,:,:], dummy, dummy = \
-                np.histogram2d(x_stranded[i,:], y_stranded[i,:],
-                               weights=weights, bins=bins)
+                H_stranded[i, :, :], dummy, dummy = np.histogram2d(
+                    x_stranded[i, :], y_stranded[i, :], weights=weights, bins=bins
+                )
 
         if density_proj is not None:
             Y, X = np.meshgrid(y_array, x_array)
@@ -3992,119 +4259,118 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         return H, H_submerged, H_stranded, lon_array, lat_array
 
     def get_residence_time(self, pixelsize_m):
-        H,H_sub, H_str,lon_array,lat_array = \
-            self.get_density_array(pixelsize_m)
+        H, H_sub, H_str, lon_array, lat_array = self.get_density_array(pixelsize_m)
         residence = np.sum(H, axis=0)
         return residence, lon_array, lat_array
 
-    def write_netcdf_density_map(self, filename, pixelsize_m='auto'):
-        '''Write netCDF file with map of particles densities'''
+    def write_netcdf_density_map(self, filename, pixelsize_m="auto"):
+        """Write netCDF file with map of particles densities"""
 
-        if pixelsize_m == 'auto':
+        if pixelsize_m == "auto":
             lon, lat = self.get_lonlats()
             latspan = lat.max() - lat.min()
             pixelsize_m = 30
-            if latspan > .05:
+            if latspan > 0.05:
                 pixelsize_m = 50
-            if latspan > .1:
+            if latspan > 0.1:
                 pixelsize_m = 300
-            if latspan > .3:
+            if latspan > 0.3:
                 pixelsize_m = 500
-            if latspan > .7:
+            if latspan > 0.7:
                 pixelsize_m = 1000
             if latspan > 2:
                 pixelsize_m = 2000
             if latspan > 5:
                 pixelsize_m = 4000
 
-        H, H_submerged, H_stranded, lon_array, lat_array = \
-            self.get_density_array(pixelsize_m)
+        H, H_submerged, H_stranded, lon_array, lat_array = self.get_density_array(
+            pixelsize_m
+        )
         lon_array = (lon_array[0:-1] + lon_array[1::]) / 2
         lat_array = (lat_array[0:-1] + lat_array[1::]) / 2
 
         from netCDF4 import Dataset, date2num
-        nc = Dataset(filename, 'w')
-        nc.createDimension('lon', len(lon_array))
-        nc.createDimension('lat', len(lat_array))
-        nc.createDimension('time', H.shape[0])
+
+        nc = Dataset(filename, "w")
+        nc.createDimension("lon", len(lon_array))
+        nc.createDimension("lat", len(lat_array))
+        nc.createDimension("time", H.shape[0])
         times = self.get_time_array()[0]
-        timestr = 'seconds since 1970-01-01 00:00:00'
-        nc.createVariable('time', 'f8', ('time', ))
-        nc.variables['time'][:] = date2num(times, timestr)
-        nc.variables['time'].units = timestr
-        nc.variables['time'].standard_name = 'time'
+        timestr = "seconds since 1970-01-01 00:00:00"
+        nc.createVariable("time", "f8", ("time",))
+        nc.variables["time"][:] = date2num(times, timestr)
+        nc.variables["time"].units = timestr
+        nc.variables["time"].standard_name = "time"
         # Projection
-        nc.createVariable('projection_lonlat', 'i8')
-        nc.variables['projection_lonlat'].grid_mapping_name = \
-            'latitude_longitude'
-        nc.variables['projection_lonlat'].earth_radius = 6371229.
-        nc.variables['projection_lonlat'].proj4 = \
-            '+proj=longlat +a=6371229 +no_defs'
+        nc.createVariable("projection_lonlat", "i8")
+        nc.variables["projection_lonlat"].grid_mapping_name = "latitude_longitude"
+        nc.variables["projection_lonlat"].earth_radius = 6371229.0
+        nc.variables["projection_lonlat"].proj4 = "+proj=longlat +a=6371229 +no_defs"
         # Coordinates
-        nc.createVariable('lon', 'f8', ('lon', ))
-        nc.createVariable('lat', 'f8', ('lat', ))
-        nc.variables['lon'][:] = lon_array
-        nc.variables['lon'].long_name = 'longitude'
-        nc.variables['lon'].short_name = 'longitude'
-        nc.variables['lon'].units = 'degrees_east'
-        nc.variables['lat'][:] = lat_array
-        nc.variables['lat'].long_name = 'latitude'
-        nc.variables['lat'].short_name = 'latitude'
-        nc.variables['lat'].units = 'degrees_north'
+        nc.createVariable("lon", "f8", ("lon",))
+        nc.createVariable("lat", "f8", ("lat",))
+        nc.variables["lon"][:] = lon_array
+        nc.variables["lon"].long_name = "longitude"
+        nc.variables["lon"].short_name = "longitude"
+        nc.variables["lon"].units = "degrees_east"
+        nc.variables["lat"][:] = lat_array
+        nc.variables["lat"].long_name = "latitude"
+        nc.variables["lat"].short_name = "latitude"
+        nc.variables["lat"].units = "degrees_north"
         # Density
-        nc.createVariable('density_surface', 'u1', ('time', 'lat', 'lon'))
-        H = np.swapaxes(H, 1, 2).astype('uint8')
+        nc.createVariable("density_surface", "u1", ("time", "lat", "lon"))
+        H = np.swapaxes(H, 1, 2).astype("uint8")
         H = np.ma.masked_where(H == 0, H)
-        nc.variables['density_surface'][:] = H
-        nc.variables['density_surface'].long_name = 'Detection probability'
-        nc.variables['density_surface'].grid_mapping = 'projection_lonlat'
-        nc.variables['density_surface'].units = '1'
+        nc.variables["density_surface"][:] = H
+        nc.variables["density_surface"].long_name = "Detection probability"
+        nc.variables["density_surface"].grid_mapping = "projection_lonlat"
+        nc.variables["density_surface"].units = "1"
         # Density submerged
-        nc.createVariable('density_submerged', 'u1', ('time', 'lat', 'lon'))
-        H_sub = np.swapaxes(H_submerged, 1, 2).astype('uint8')
+        nc.createVariable("density_submerged", "u1", ("time", "lat", "lon"))
+        H_sub = np.swapaxes(H_submerged, 1, 2).astype("uint8")
         H_sub = np.ma.masked_where(H_sub == 0, H_sub)
-        nc.variables['density_submerged'][:] = H_sub
-        nc.variables[
-            'density_submerged'].long_name = 'Detection probability submerged'
-        nc.variables['density_submerged'].grid_mapping = 'projection_lonlat'
-        nc.variables['density_submerged'].units = '1'
+        nc.variables["density_submerged"][:] = H_sub
+        nc.variables["density_submerged"].long_name = "Detection probability submerged"
+        nc.variables["density_submerged"].grid_mapping = "projection_lonlat"
+        nc.variables["density_submerged"].units = "1"
         # Density stranded
-        nc.createVariable('density_stranded', 'u1', ('time', 'lat', 'lon'))
-        H_stranded = np.swapaxes(H_stranded, 1, 2).astype('uint8')
+        nc.createVariable("density_stranded", "u1", ("time", "lat", "lon"))
+        H_stranded = np.swapaxes(H_stranded, 1, 2).astype("uint8")
         H_stranded = np.ma.masked_where(H_stranded == 0, H_stranded)
-        nc.variables['density_stranded'][:] = H_stranded
-        nc.variables[
-            'density_stranded'].long_name = 'Detection probability stranded'
-        nc.variables['density_stranded'].grid_mapping = 'projection_lonlat'
-        nc.variables['density_stranded'].units = '1'
+        nc.variables["density_stranded"][:] = H_stranded
+        nc.variables["density_stranded"].long_name = "Detection probability stranded"
+        nc.variables["density_stranded"].grid_mapping = "projection_lonlat"
+        nc.variables["density_stranded"].units = "1"
 
         nc.close()
 
-    def write_netcdf_density_map_proj(self,
-                                      filename,
-                                      pixelsize_m='auto',
-                                      density_proj=None,
-                                      llcrnrlon=None,
-                                      llcrnrlat=None,
-                                      urcrnrlon=None,
-                                      urcrnrlat=None):
-        '''Write netCDF file with map of particles densities for a given projection or area'''
+    def write_netcdf_density_map_proj(
+        self,
+        filename,
+        pixelsize_m="auto",
+        density_proj=None,
+        llcrnrlon=None,
+        llcrnrlat=None,
+        urcrnrlon=None,
+        urcrnrlat=None,
+    ):
+        """Write netCDF file with map of particles densities for a given projection or area"""
         #
         # TODO: should be merged with write_netcdf_density_map_proj
         # KFD Jan 2021
         #
 
-        if pixelsize_m == 'auto':
+        if pixelsize_m == "auto":
             lon, lat = self.get_lonlats()
             latspan = lat.max() - lat.min()
             pixelsize_m = 30
-            if latspan > .05:
+            if latspan > 0.05:
                 pixelsize_m = 50
-            if latspan > .1:
+            if latspan > 0.1:
                 pixelsize_m = 300
-            if latspan > .3:
+            if latspan > 0.3:
                 pixelsize_m = 500
-            if latspan > .7:
+            if latspan > 0.7:
                 pixelsize_m = 1000
             if latspan > 2:
                 pixelsize_m = 2000
@@ -4112,88 +4378,90 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 pixelsize_m = 4000
 
         if density_proj is None:  # add default projection with equal-area property
-            density_proj = pyproj.Proj('+proj=moll +ellps=WGS84 +lon_0=0.0')
+            density_proj = pyproj.Proj("+proj=moll +ellps=WGS84 +lon_0=0.0")
 
-
-        H, H_submerged, H_stranded, lon_array, lat_array = \
-                self.get_density_array_proj(pixelsize_m=pixelsize_m,
-                                       density_proj=density_proj,
-                                       llcrnrlon=llcrnrlon, llcrnrlat=llcrnrlat,
-                                       urcrnrlon=urcrnrlon, urcrnrlat=urcrnrlat)
+        H, H_submerged, H_stranded, lon_array, lat_array = self.get_density_array_proj(
+            pixelsize_m=pixelsize_m,
+            density_proj=density_proj,
+            llcrnrlon=llcrnrlon,
+            llcrnrlat=llcrnrlat,
+            urcrnrlon=urcrnrlon,
+            urcrnrlat=urcrnrlat,
+        )
         # calculate center coordinates
         print(lon_array.shape, lat_array.shape)
-        lon_array = (lon_array[:-1, :-1] + lon_array[1:, 1:]) / 2.
-        lat_array = (lat_array[:-1, :-1] + lat_array[1:, 1:]) / 2.
+        lon_array = (lon_array[:-1, :-1] + lon_array[1:, 1:]) / 2.0
+        lat_array = (lat_array[:-1, :-1] + lat_array[1:, 1:]) / 2.0
 
         from netCDF4 import Dataset, date2num
-        nc = Dataset(filename, 'w')
-        nc.createDimension('x', lon_array.shape[0])
-        nc.createDimension('y', lon_array.shape[1])
-        nc.createDimension('time', H.shape[0])
+
+        nc = Dataset(filename, "w")
+        nc.createDimension("x", lon_array.shape[0])
+        nc.createDimension("y", lon_array.shape[1])
+        nc.createDimension("time", H.shape[0])
         times = self.get_time_array()[0]
-        timestr = 'seconds since 1970-01-01 00:00:00'
-        nc.createVariable('time', 'f8', ('time', ))
-        nc.variables['time'][:] = date2num(times, timestr)
-        nc.variables['time'].units = timestr
-        nc.variables['time'].standard_name = 'time'
+        timestr = "seconds since 1970-01-01 00:00:00"
+        nc.createVariable("time", "f8", ("time",))
+        nc.variables["time"][:] = date2num(times, timestr)
+        nc.variables["time"].units = timestr
+        nc.variables["time"].standard_name = "time"
         # Projection
 
-        nc.createVariable('projection', 'i8')
-        nc.variables['projection'].proj4 = density_proj.definition_string()
+        nc.createVariable("projection", "i8")
+        nc.variables["projection"].proj4 = density_proj.definition_string()
         # Coordinates
-        nc.createVariable('lon', 'f8', ('y', 'x'))
-        nc.createVariable('lat', 'f8', ('y', 'x'))
-        nc.variables['lon'][:] = lon_array.T
-        nc.variables['lon'].long_name = 'longitude'
-        nc.variables['lon'].short_name = 'longitude'
-        nc.variables['lon'].units = 'degrees_east'
-        nc.variables['lat'][:] = lat_array.T
-        nc.variables['lat'].long_name = 'latitude'
-        nc.variables['lat'].short_name = 'latitude'
-        nc.variables['lat'].units = 'degrees_north'
+        nc.createVariable("lon", "f8", ("y", "x"))
+        nc.createVariable("lat", "f8", ("y", "x"))
+        nc.variables["lon"][:] = lon_array.T
+        nc.variables["lon"].long_name = "longitude"
+        nc.variables["lon"].short_name = "longitude"
+        nc.variables["lon"].units = "degrees_east"
+        nc.variables["lat"][:] = lat_array.T
+        nc.variables["lat"].long_name = "latitude"
+        nc.variables["lat"].short_name = "latitude"
+        nc.variables["lat"].units = "degrees_north"
 
         # Density
-        nc.createVariable('density_surface', 'u1', ('time', 'y', 'x'))
-        H = np.swapaxes(H, 1, 2).astype('uint8')
+        nc.createVariable("density_surface", "u1", ("time", "y", "x"))
+        H = np.swapaxes(H, 1, 2).astype("uint8")
         H = np.ma.masked_where(H == 0, H)
-        nc.variables['density_surface'][:] = H
-        nc.variables['density_surface'].long_name = 'Detection probability'
-        nc.variables['density_surface'].grid_mapping = 'projection'
-        nc.variables['density_surface'].units = '1'
+        nc.variables["density_surface"][:] = H
+        nc.variables["density_surface"].long_name = "Detection probability"
+        nc.variables["density_surface"].grid_mapping = "projection"
+        nc.variables["density_surface"].units = "1"
         # Density submerged
-        nc.createVariable('density_submerged', 'u1', ('time', 'y', 'x'))
-        H_sub = np.swapaxes(H_submerged, 1, 2).astype('uint8')
+        nc.createVariable("density_submerged", "u1", ("time", "y", "x"))
+        H_sub = np.swapaxes(H_submerged, 1, 2).astype("uint8")
         H_sub = np.ma.masked_where(H_sub == 0, H_sub)
-        nc.variables['density_submerged'][:] = H_sub
-        nc.variables[
-            'density_submerged'].long_name = 'Detection probability submerged'
-        nc.variables['density_submerged'].grid_mapping = 'projection'
-        nc.variables['density_submerged'].units = '1'
+        nc.variables["density_submerged"][:] = H_sub
+        nc.variables["density_submerged"].long_name = "Detection probability submerged"
+        nc.variables["density_submerged"].grid_mapping = "projection"
+        nc.variables["density_submerged"].units = "1"
         # Density stranded
-        nc.createVariable('density_stranded', 'u1', ('time', 'y', 'x'))
-        H_stranded = np.swapaxes(H_stranded, 1, 2).astype('uint8')
+        nc.createVariable("density_stranded", "u1", ("time", "y", "x"))
+        H_stranded = np.swapaxes(H_stranded, 1, 2).astype("uint8")
         H_stranded = np.ma.masked_where(H_stranded == 0, H_stranded)
-        nc.variables['density_stranded'][:] = H_stranded
-        nc.variables[
-            'density_stranded'].long_name = 'Detection probability stranded'
-        nc.variables['density_stranded'].grid_mapping = 'projection'
-        nc.variables['density_stranded'].units = '1'
+        nc.variables["density_stranded"][:] = H_stranded
+        nc.variables["density_stranded"].long_name = "Detection probability stranded"
+        nc.variables["density_stranded"].grid_mapping = "projection"
+        nc.variables["density_stranded"].units = "1"
 
         nc.close()
 
-    def write_geotiff(self, filename, pixelsize_km=.2):
-        '''Write one GeoTiff image per timestep.
+    def write_geotiff(self, filename, pixelsize_km=0.2):
+        """Write one GeoTiff image per timestep.
 
         filename should contain date identifiers, e.g. 'img_%Y%m%d_%H%M.tif'
         https://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
-        '''
+        """
 
         try:
             from osgeo import gdal, osr
         except:
-            raise ValueError('GDAL is needed to write geotiff images.')
+            raise ValueError("GDAL is needed to write geotiff images.")
         import matplotlib.pyplot as plt
-        driver = gdal.GetDriverByName('GTiff')
+
+        driver = gdal.GetDriverByName("GTiff")
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(4326)
         colortable = gdal.ColorTable()
@@ -4203,28 +4471,22 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         colortable.SetColorEntry(3, (0, 255, 0, 255))
         colortable.SetColorEntry(4, (0, 0, 255, 255))
 
-        lon = self.get_property('lon')[0]
-        lat = self.get_property('lat')[0]
-        status = self.get_property('status')[0]
+        lon = self.get_property("lon")[0]
+        lat = self.get_property("lat")[0]
+        status = self.get_property("status")[0]
         times = self.get_time_array()[0]
         deltalat = pixelsize_km / 111.0  # km to degrees
         deltalon = deltalat / np.cos(np.radians((lat.min() + lat.max()) / 2))
-        lat_array = np.arange(lat.min() - deltalat,
-                              lat.max() + deltalat, deltalat)
-        lon_array = np.arange(lon.min() - deltalat,
-                              lon.max() + deltalon, deltalon)
+        lat_array = np.arange(lat.min() - deltalat, lat.max() + deltalat, deltalat)
+        lon_array = np.arange(lon.min() - deltalat, lon.max() + deltalon, deltalon)
         ilon = (np.round((lon - lon.min()) / deltalon)).astype(int)
         ilat = (np.round((lat - lat.min()) / deltalat)).astype(int)
         # Setting masked values to zero, for use as indices
         ilon[ilon.mask] = 0
         ilat[ilat.mask] = 0
         status[ilon.mask] = 0
-        image = np.zeros(
-            (len(times), len(lon_array), len(lat_array))).astype(int)
-        geotransform = [
-            lon_array.min(), deltalon, 0,
-            lat_array.max(), 0, -deltalat
-        ]
+        image = np.zeros((len(times), len(lon_array), len(lat_array))).astype(int)
+        geotransform = [lon_array.min(), deltalon, 0, lat_array.max(), 0, -deltalat]
         for i, t in enumerate(times):
             image[i, ilon[i, :], ilat[i, :]] = status[i, :] + 1
             filename_i = t.strftime(filename)
@@ -4247,51 +4509,53 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         """Return a list of output times of last run."""
 
         # Making sure start_time is datetime, and not cftime object
-        self.start_time = datetime(self.start_time.year, self.start_time.month,
-                                   self.start_time.day, self.start_time.hour,
-                                   self.start_time.minute,
-                                   self.start_time.second)
+        self.start_time = datetime(
+            self.start_time.year,
+            self.start_time.month,
+            self.start_time.day,
+            self.start_time.hour,
+            self.start_time.minute,
+            self.start_time.second,
+        )
         td = self.time_step_output
-        time_array = [
-            self.start_time + td * i for i in range(self.steps_output)
-        ]
+        time_array = [self.start_time + td * i for i in range(self.steps_output)]
         time_array_relative = [td * i for i in range(self.steps_output)]
         return time_array, time_array_relative
 
     @require_mode(mode=Mode.Result)
     def plot_environment(self, filename=None, ax=None, show=True):
         """Plot mean wind and current velocities of element of last run."""
-        x_wind = self.get_property('x_wind')[0]
-        y_wind = self.get_property('y_wind')[0]
+        x_wind = self.get_property("x_wind")[0]
+        y_wind = self.get_property("y_wind")[0]
         wind = np.sqrt(x_wind**2 + y_wind**2)
-        x_sea_water_velocity = self.get_property('x_sea_water_velocity')[0]
-        y_sea_water_velocity = self.get_property('y_sea_water_velocity')[0]
+        x_sea_water_velocity = self.get_property("x_sea_water_velocity")[0]
+        y_sea_water_velocity = self.get_property("y_sea_water_velocity")[0]
         current = np.sqrt(x_sea_water_velocity**2 + y_sea_water_velocity**2)
         wind = np.ma.mean(wind, axis=1)
         current = np.ma.mean(current, axis=1)
         time, time_relative = self.get_time_array()
-        time = np.array([t.total_seconds() / 3600. for t in time_relative])
+        time = np.array([t.total_seconds() / 3600.0 for t in time_relative])
 
         if ax is None:
             fig = plt.figure()
             ax = fig.add_subplot(111)
-        ax.plot(time, wind, 'b', label='Wind speed')
-        ax.set_ylabel('Wind speed  [m/s]', color='b')
+        ax.plot(time, wind, "b", label="Wind speed")
+        ax.set_ylabel("Wind speed  [m/s]", color="b")
         ax.set_xlim([0, time[-1]])
         ax.set_ylim([0, wind.max() * 1.1])
 
         ax2 = ax.twinx()
-        ax2.plot(time, current, 'r', label='Current speed')
-        ax2.set_ylabel('Current speed  [m/s]', color='r')
+        ax2.plot(time, current, "r", label="Current speed")
+        ax2.set_ylabel("Current speed  [m/s]", color="r")
         ax2.set_xlim([0, time[-1]])
         ax2.set_ylim([0, current.max() * 1.1])
         for tl in ax.get_yticklabels():
-            tl.set_color('b')
+            tl.set_color("b")
         for tl in ax2.get_yticklabels():
-            tl.set_color('r')
-        ax.set_xlabel('Time  [hours]')
-        ax.legend(loc='upper left')
-        ax2.legend(loc='lower right')
+            tl.set_color("r")
+        ax.set_xlabel("Time  [hours]")
+        ax.legend(loc="upper left")
+        ax2.legend(loc="lower right")
 
         if filename is None:
             if show is True:
@@ -4305,32 +4569,35 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         import matplotlib.pyplot as plt
         from matplotlib import dates
 
-        hfmt = dates.DateFormatter('%d %b %Y %H:%M')
+        hfmt = dates.DateFormatter("%d %b %Y %H:%M")
         fig = plt.figure()
         ax = fig.gca()
         ax.xaxis.set_major_formatter(hfmt)
-        plt.xticks(rotation='vertical')
+        plt.xticks(rotation="vertical")
         start_time = self.start_time
         # In case start_time is unsupported cftime
-        start_time = datetime(start_time.year, start_time.month,
-                              start_time.day, start_time.hour,
-                              start_time.minute, start_time.second)
+        start_time = datetime(
+            start_time.year,
+            start_time.month,
+            start_time.day,
+            start_time.hour,
+            start_time.minute,
+            start_time.second,
+        )
         times = [
-            start_time + n * self.time_step_output
-            for n in range(self.steps_output)
+            start_time + n * self.time_step_output for n in range(self.steps_output)
         ]
-        data = self.history[prop].T[0:len(times), :]
+        data = self.history[prop].T[0 : len(times), :]
         if mean is True:  # Taking average over elements
             data = np.mean(data, axis=1)
         plt.plot(times, data)
         plt.title(prop)
-        plt.xlabel('Time  [UTC]')
+        plt.xlabel("Time  [UTC]")
         try:
-            plt.ylabel('%s  [%s]' %
-                       (prop, self.elements.variables[prop]['units']))
+            plt.ylabel("%s  [%s]" % (prop, self.elements.variables[prop]["units"]))
         except:
             plt.ylabel(prop)
-        plt.subplots_adjust(bottom=.3)
+        plt.subplots_adjust(bottom=0.3)
         plt.grid()
         if filename is None:
             plt.show()
@@ -4340,10 +4607,9 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
     @require_mode(mode=Mode.Result)
     def get_property(self, propname):
         """Get property from history, sorted by status."""
-        index_of_first, index_of_last = \
-            self.index_of_activation_and_deactivation()
+        index_of_first, index_of_last = self.index_of_activation_and_deactivation()
         prop = self.history[propname].copy()
-        status = self.history['status'].copy()
+        status = self.history["status"].copy()
         j = np.arange(status.shape[1])
         # Fill arrays with last value before deactivation
         for i in range(status.shape[0]):
@@ -4355,15 +4621,15 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
     @require_mode(mode=Mode.Result)
     def get_trajectory_lengths(self):
         """Calculate lengths and speeds along trajectories."""
-        lons = self.get_property('lon')[0]
-        lats = self.get_property('lat')[0]
-        geod = pyproj.Geod(ellps='WGS84')
-        a1, a2, distances = geod.inv(lons[0:-1, :], lats[0:-1, :],
-                                     lons[1::, :], lats[1::, :])
+        lons = self.get_property("lon")[0]
+        lats = self.get_property("lat")[0]
+        geod = pyproj.Geod(ellps="WGS84")
+        a1, a2, distances = geod.inv(
+            lons[0:-1, :], lats[0:-1, :], lons[1::, :], lats[1::, :]
+        )
         distances[np.isnan(distances)] = 0
         speeds = distances / self.time_step_output.total_seconds()
-        distances[speeds >
-                  100] = 0  # TODO: need better way to mask invalid distances
+        distances[speeds > 100] = 0  # TODO: need better way to mask invalid distances
         speeds[speeds > 100] = 0  #       due to masked lons/lats arrays
         total_length = np.cumsum(distances, 0)[-1, :]
 
@@ -4382,7 +4648,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                              x- and y-axes of the inherit SRS (proj4).
         """
 
-        geod = pyproj.Geod(ellps='WGS84')
+        geod = pyproj.Geod(ellps="WGS84")
 
         azimuth = np.degrees(np.arctan2(x_vel, y_vel))  # Direction of motion
         velocity = np.sqrt(x_vel**2 + y_vel**2)  # Velocity in m/s
@@ -4390,93 +4656,108 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         # Calculate new positions
         self.elements.lon, self.elements.lat, back_az = geod.fwd(
-            self.elements.lon, self.elements.lat, azimuth,
-            velocity * self.time_step.total_seconds())
+            self.elements.lon,
+            self.elements.lat,
+            azimuth,
+            velocity * self.time_step.total_seconds(),
+        )
 
         # Check that new positions are valid
-        if (self.elements.lon.min()
-                < -180) or (self.elements.lon.min()
-                            > 360) or (self.elements.lat.min()
-                                       < -90) or (self.elements.lat.max()
-                                                  > 90):
-            logger.info('Invalid new coordinates:')
+        if (
+            (self.elements.lon.min() < -180)
+            or (self.elements.lon.min() > 360)
+            or (self.elements.lat.min() < -90)
+            or (self.elements.lat.max() > 90)
+        ):
+            logger.info("Invalid new coordinates:")
             logger.info(self.elements)
-            sys.exit('Quitting')
+            sys.exit("Quitting")
 
     def __repr__(self):
         """String representation providing overview of model status."""
-        outStr = '===========================\n'
+        outStr = "===========================\n"
         if self.history is not None:
             outStr += self.performance()
-            outStr += '===========================\n'
-        outStr += 'Model:\t' + type(self).__name__ + \
-            '     (OpenDrift version %s)\n' % opendrift.__version__
-        outStr += '\t%s active %s particles  (%s deactivated, %s scheduled)\n'\
-            % (self.num_elements_active(), self.ElementType.__name__,
-               self.num_elements_deactivated(), self.num_elements_scheduled())
+            outStr += "===========================\n"
+        outStr += (
+            "Model:\t"
+            + type(self).__name__
+            + "     (OpenDrift version %s)\n" % opendrift.__version__
+        )
+        outStr += "\t%s active %s particles  (%s deactivated, %s scheduled)\n" % (
+            self.num_elements_active(),
+            self.ElementType.__name__,
+            self.num_elements_deactivated(),
+            self.num_elements_scheduled(),
+        )
         variable_groups, reader_groups, missing = self.env.get_reader_groups()
-        outStr += '-------------------\n'
-        outStr += 'Environment variables:\n'
+        outStr += "-------------------\n"
+        outStr += "Environment variables:\n"
         for i, variableGroup in enumerate(variable_groups):
-            outStr += '  -----\n'
+            outStr += "  -----\n"
             readerGroup = reader_groups[i]
             for variable in sorted(variableGroup):
-                outStr += '  ' + variable + '\n'
+                outStr += "  " + variable + "\n"
             for i, reader in enumerate(readerGroup):
-                outStr += '     ' + str(i + 1) + ') ' + reader + '\n'
+                outStr += "     " + str(i + 1) + ") " + reader + "\n"
         if len(self.env.missing_variables()) > 0:
-            outStr += '  -----\n'
-            outStr += 'Readers not added for the following variables:\n'
+            outStr += "  -----\n"
+            outStr += "Readers not added for the following variables:\n"
             for variable in sorted(self.env.missing_variables()):
-                outStr += '  ' + variable + '\n'
+                outStr += "  " + variable + "\n"
 
         lazy_readers = [
             r for r in self.env.readers if self.env.readers[r].is_lazy is True
         ]
         if len(lazy_readers) > 0:
-            outStr += '---\nLazy readers:\n'
+            outStr += "---\nLazy readers:\n"
             for lr in lazy_readers:
-                outStr += '  ' + lr + '\n'
+                outStr += "  " + lr + "\n"
 
-        outStr += '\nDiscarded readers:\n'
+        outStr += "\nDiscarded readers:\n"
         for dr, reason in self.env.discarded_readers.items():
-            outStr += '  %s (%s)\n' % (dr, reason)
+            outStr += "  %s (%s)\n" % (dr, reason)
 
-        if hasattr(self, 'time'):
-            outStr += '\nTime:\n'
-            outStr += '\tStart: %s UTC\n' % (self.start_time)
-            outStr += '\tPresent: %s UTC\n' % (self.time)
-            if hasattr(self, 'time_step'):
-                outStr += '\tCalculation steps: %i * %s - total time: %s\n' % (
-                    self.steps_calculation, self.time_step,
-                    self.time - self.start_time)
-                outStr += '\tOutput steps: %i * %s\n' % (self.steps_output,
-                                                         self.time_step_output)
-        if hasattr(self, 'messages'):
-            outStr += '-------------------\n'
+        if hasattr(self, "time"):
+            outStr += "\nTime:\n"
+            outStr += "\tStart: %s UTC\n" % (self.start_time)
+            outStr += "\tPresent: %s UTC\n" % (self.time)
+            if hasattr(self, "time_step"):
+                outStr += "\tCalculation steps: %i * %s - total time: %s\n" % (
+                    self.steps_calculation,
+                    self.time_step,
+                    self.time - self.start_time,
+                )
+                outStr += "\tOutput steps: %i * %s\n" % (
+                    self.steps_output,
+                    self.time_step_output,
+                )
+        if hasattr(self, "messages"):
+            outStr += "-------------------\n"
             outStr += self.get_messages()
-        outStr += '===========================\n'
+        outStr += "===========================\n"
         return outStr
 
     def store_message(self, message):
         """Store important messages to be displayed to user at end."""
-        if not hasattr(self, 'messages'):
+        if not hasattr(self, "messages"):
             self.messages = []
         self.messages.append(message)
 
     def get_messages(self):
         """Report any messages stored during simulation."""
 
-        if hasattr(self, 'messages'):
-            return str(self.messages).strip('[]') + '\n'
+        if hasattr(self, "messages"):
+            return str(self.messages).strip("[]") + "\n"
         else:
-            return ''
+            return ""
 
     def add_halo_readers(self):
         """Adding some Thredds and file readers in prioritised order"""
 
-        self.add_readers_from_file(self.test_data_folder() +
-                                   '../../opendrift/scripts/data_sources.txt')
+        self.add_readers_from_file(
+            self.test_data_folder() + "../../opendrift/scripts/data_sources.txt"
+        )
 
     def _sphinx_gallery_filename(self, stack_offset=3):
         # This assumes that the calling script is three frames up in the stack.
@@ -4486,13 +4767,13 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         caller = os.path.splitext(os.path.basename(caller.filename))[0]
 
         # Calling script is string input (e.g. from ..plot::)
-        if caller == '<string>':
-            caller = 'plot_directive'
-            adir = os.path.realpath('../source/gallery/animations')
+        if caller == "<string>":
+            caller = "plot_directive"
+            adir = os.path.realpath("../source/gallery/animations")
         else:
-            adir = os.path.realpath('../docs/source/gallery/animations')
+            adir = os.path.realpath("../docs/source/gallery/animations")
 
-        if not hasattr(OpenDriftSimulation, '__anim_no__'):
+        if not hasattr(OpenDriftSimulation, "__anim_no__"):
             OpenDriftSimulation.__anim_no__ = {}
 
         if caller not in OpenDriftSimulation.__anim_no__:
@@ -4500,57 +4781,57 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         os.makedirs(adir, exist_ok=True)
 
-        filename = '%s_%d.gif' % (caller,
-                                  OpenDriftSimulation.__anim_no__[caller])
+        filename = "%s_%d.gif" % (caller, OpenDriftSimulation.__anim_no__[caller])
         OpenDriftSimulation.__anim_no__[caller] += 1
 
         filename = os.path.join(adir, filename)
 
         return filename
 
-    def __save_animation__(self, fig, plot_timestep, filename, frames, fps,
-                           blit, interval):
+    def __save_animation__(
+        self, fig, plot_timestep, filename, frames, fps, blit, interval
+    ):
 
-        if filename is None or 'sphinx_gallery' in sys.modules:
+        if filename is None or "sphinx_gallery" in sys.modules:
             stack_offset = 4
             import gc
+
             fr = sys._getframe(2)
             for o in gc.get_objects():
                 if inspect.isfunction(o) and o.__code__ is fr.f_code:
-                    if hasattr(getattr(self, o.__name__), '__wrapped__'):
+                    if hasattr(getattr(self, o.__name__), "__wrapped__"):
                         stack_offset = 5
             filename = self._sphinx_gallery_filename(stack_offset=stack_offset)
 
-        logger.info('Saving animation to ' + str(filename) + '...')
+        logger.info("Saving animation to " + str(filename) + "...")
 
         start_time = datetime.now()
 
         writer = None
 
-        if str(filename)[-4:] == '.gif':
+        if str(filename)[-4:] == ".gif":
             writer = animation.PillowWriter(fps=fps)
             # writer=animation.ImageMagickWriter(fps=fps)
-        elif str(filename)[-4:] == '.mp4':
+        elif str(filename)[-4:] == ".mp4":
             writer = animation.FFMpegWriter(
                 fps=fps,
-                codec='libx264',
+                codec="libx264",
                 bitrate=1800,
                 extra_args=[
-                    '-profile:v',
-                    'baseline',
-                    '-vf',
-                    'crop=trunc(iw/2)*2:trunc(ih/2)*2',  # cropping 1 pixel if not even
-                    '-pix_fmt',
-                    'yuv420p',
-                    '-an'
-                ])
+                    "-profile:v",
+                    "baseline",
+                    "-vf",
+                    "crop=trunc(iw/2)*2:trunc(ih/2)*2",  # cropping 1 pixel if not even
+                    "-pix_fmt",
+                    "yuv420p",
+                    "-an",
+                ],
+            )
         else:
             # fallback to using funcwriter
-            anim = animation.FuncAnimation(fig,
-                                           plot_timestep,
-                                           blit=blit,
-                                           frames=frames,
-                                           interval=interval)
+            anim = animation.FuncAnimation(
+                fig, plot_timestep, blit=blit, frames=frames, interval=interval
+            )
             anim.save(filename)
 
         if writer is not None:
@@ -4561,24 +4842,25 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         logger.debug(f"MPLBACKEND = {matplotlib.get_backend()}")
         logger.debug(f"DISPLAY = {os.environ.get('DISPLAY', 'None')}")
-        logger.debug('Time to save animation: %s' %
-                     (datetime.now() - start_time))
+        logger.debug("Time to save animation: %s" % (datetime.now() - start_time))
 
         plt.close()
 
-    def calculate_ftle(self,
-                       reader=None,
-                       delta=None,
-                       domain=None,
-                       time=None,
-                       time_step=None,
-                       duration=None,
-                       z=0,
-                       RLCS=True,
-                       ALCS=True):
+    def calculate_ftle(
+        self,
+        reader=None,
+        delta=None,
+        domain=None,
+        time=None,
+        time_step=None,
+        duration=None,
+        z=0,
+        RLCS=True,
+        ALCS=True,
+    ):
 
         if reader is None:
-            logger.info('No reader provided, using first available:')
+            logger.info("No reader provided, using first available:")
             reader = list(self.env.readers.items())[0][1]
             logger.info(reader.name)
         if isinstance(reader, pyproj.Proj):
@@ -4609,36 +4891,37 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         if not isinstance(time, list):
             time = [time]
         # dictionary to hold LCS calculation
-        lcs = {'time': time, 'lon': lons, 'lat': lats}
-        lcs['RLCS'] = np.zeros((len(time), len(ys), len(xs)))
-        lcs['ALCS'] = np.zeros((len(time), len(ys), len(xs)))
+        lcs = {"time": time, "lon": lons, "lat": lats}
+        lcs["RLCS"] = np.zeros((len(time), len(ys), len(xs)))
+        lcs["ALCS"] = np.zeros((len(time), len(ys), len(xs)))
         T = np.abs(duration.total_seconds())
         for i, t in enumerate(time):
-            logger.info('Calculating LCS for ' + str(t))
+            logger.info("Calculating LCS for " + str(t))
             # Forwards
             if RLCS is True:
                 o = self.clone()
                 o.seed_elements(lons.ravel(), lats.ravel(), time=t, z=z)
                 o.run(duration=duration, time_step=time_step)
-                f_x1, f_y1 = proj(o.history['lon'].T[-1].reshape(X.shape),
-                                  o.history['lat'].T[-1].reshape(X.shape))
-                lcs['RLCS'][i, :, :] = ftle(f_x1 - X, f_y1 - Y, delta, T)
+                f_x1, f_y1 = proj(
+                    o.history["lon"].T[-1].reshape(X.shape),
+                    o.history["lat"].T[-1].reshape(X.shape),
+                )
+                lcs["RLCS"][i, :, :] = ftle(f_x1 - X, f_y1 - Y, delta, T)
             # Backwards
             if ALCS is True:
                 o = self.clone()
-                o.seed_elements(lons.ravel(),
-                                lats.ravel(),
-                                time=t + duration,
-                                z=z)
+                o.seed_elements(lons.ravel(), lats.ravel(), time=t + duration, z=z)
                 o.run(duration=duration, time_step=-time_step)
-                b_x1, b_y1 = proj(o.history['lon'].T[-1].reshape(X.shape),
-                                  o.history['lat'].T[-1].reshape(X.shape))
-                lcs['ALCS'][i, :, :] = ftle(b_x1 - X, b_y1 - Y, delta, T)
+                b_x1, b_y1 = proj(
+                    o.history["lon"].T[-1].reshape(X.shape),
+                    o.history["lat"].T[-1].reshape(X.shape),
+                )
+                lcs["ALCS"][i, :, :] = ftle(b_x1 - X, b_y1 - Y, delta, T)
 
-        lcs['RLCS'] = np.ma.masked_invalid(lcs['RLCS'])
-        lcs['ALCS'] = np.ma.masked_invalid(lcs['ALCS'])
+        lcs["RLCS"] = np.ma.masked_invalid(lcs["RLCS"])
+        lcs["ALCS"] = np.ma.masked_invalid(lcs["ALCS"])
         # Flipping ALCS left-right. Not sure why this is needed
-        lcs['ALCS'] = lcs['ALCS'][:, ::-1, ::-1]
+        lcs["ALCS"] = lcs["ALCS"][:, ::-1, ::-1]
 
         return lcs
 
@@ -4648,11 +4931,11 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         returns  (lon,lat), variance
         where (lon,lat) are the coordinates of the center of mass as
         function of time"""
-        #lon,lat = self.get_property('lon')[0], self.get_property('lat')[0]
-        lon, lat = self.history['lon'], self.history['lat']
+        # lon,lat = self.get_property('lon')[0], self.get_property('lat')[0]
+        lon, lat = self.history["lon"], self.history["lat"]
         x, y = self.proj_latlon(lon, lat)
         if onlysurface == True:
-            z = self.history['z']
+            z = self.history["z"]
             submerged = z < 0
             x = np.ma.array(x, mask=submerged)
             y = np.ma.array(y, mask=submerged)
@@ -4661,10 +4944,10 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         center = self.proj_latlon(x_m, y_m, inverse=True)
         one = np.ones_like(x)
         # variance:
-        variance = np.ma.mean((x - x_m * one)**2 + (y - y_m * one)**2, axis=0)
+        variance = np.ma.mean((x - x_m * one) ** 2 + (y - y_m * one) ** 2, axis=0)
 
         return center, variance
 
     def gui_postproc(self):
-        '''To be overloaded by subclasses'''
+        """To be overloaded by subclasses"""
         pass

--- a/opendrift/models/basemodel/environment.py
+++ b/opendrift/models/basemodel/environment.py
@@ -851,14 +851,13 @@ class Environment(Timeable, Configurable):
                     env_profiles['sea_water_temperature'][:,t_kelvin] = \
                       env_profiles['sea_water_temperature'][:,t_kelvin] - 273.15
 
-        #######################################################
+        ############################################################
         # Parameterisation of unavailable variables
-        #######################################################
+        # TODO: use instead "environment mapping" mechanism for this
+        #############################################################
         if 'drift:use_tabularised_stokes_drift' in self._config and self.get_config(
                 'drift:use_tabularised_stokes_drift') is True:
-            if 'x_wind' not in variables:
-                logger.debug('No wind available to calculate Stokes drift')
-            else:
+            if 'x_wind' in variables:
                 if 'sea_surface_wave_stokes_drift_x_velocity' not in variables or (
                         env['sea_surface_wave_stokes_drift_x_velocity'].max()
                         == 0 and

--- a/opendrift/readers/basereader/structured.py
+++ b/opendrift/readers/basereader/structured.py
@@ -34,6 +34,10 @@ class StructuredReader(Variables):
     y = None
     interpolation = 'linearNDFast'
     convolve = None  # Convolution kernel or kernel size
+    # set these in reader to save interpolators to file
+    save_interpolator = None
+    interpolator_filename = None
+    
 
     # Used to enable and track status of parallel coordinate transformations.
     __lonlat2xy_parallel__ = None
@@ -70,13 +74,13 @@ class StructuredReader(Variables):
     
             # Making interpolator (lon, lat) -> x
             # save to speed up next time
-            if hasattr(self, "save_interpolator") and self.save_interpolator and hasattr(self, "interpolator_filename"):
+            if self.save_interpolator and self.interpolator_filename is not None:
                 interpolator_filename = Path(self.interpolator_filename).with_suffix('.pickle')
             else:
                 interpolator_filename = f'{self.name}_interpolators.pickle'
             
-            if hasattr(self, "save_interpolator") and self.save_interpolator and Path(interpolator_filename).is_file():
-                logger.info('Loading interpolator for lon,lat to x,y conversion...')
+            if self.save_interpolator and Path(interpolator_filename).is_file():
+                logger.info('Loading previously saved interpolator for lon,lat to x,y conversion.')
                 with open(interpolator_filename, 'rb') as file_handle:
                     interp_dict = pickle.load(file_handle)
                     spl_x = interp_dict["spl_x"]
@@ -100,7 +104,8 @@ class StructuredReader(Variables):
                 # https://github.com/scipy/scipy/issues/8856
                 spl_x((0, 0)), spl_y((0, 0))
                 
-                if hasattr(self, "save_interpolator") and self.save_interpolator:
+                if self.save_interpolator:
+                    logger.info('Saving interpolator for lon,lat to x,y conversion.')
 
                     interp_dict = {"spl_x": spl_x, "spl_y": spl_y}
                     with open(interpolator_filename, 'wb') as f:

--- a/opendrift/readers/reader_ROMS_native.py
+++ b/opendrift/readers/reader_ROMS_native.py
@@ -42,8 +42,8 @@ class Reader(BaseReader, StructuredReader):
         :param save_interpolator: Whether or not to save the interpolator that goes from lon/lat to x/y (calculated in structured.py)
         :type save_interpolator: bool
 
-        :param interpolator_path: If save_interpolator is True, user can input this string to control where interpolator is saved.
-        :type interpolator_path: Path, str, optional
+        :param interpolator_filename: If save_interpolator is True, user can input this string to control where interpolator is saved.
+        :type interpolator_filename: Path, str, optional
 
     Example:
 
@@ -76,7 +76,16 @@ class Reader(BaseReader, StructuredReader):
     """
 
     def __init__(self, filename=None, name=None, gridfile=None, standard_name_mapping={},
-                 save_interpolator=False, interpolator_path=None):
+                 save_interpolator=False, interpolator_filename=None):
+        
+        self._mask_rho = None
+        self._mask_u = None
+        self._mask_v = None
+        self.land_binary_mask = None
+        self.sea_floor_depth_below_sea_level = None
+        self.z_rho_tot = None
+        self.s2z_A = None
+        self.angle_xi_east = None
 
         if filename is None:
             raise ValueError('Need filename as argument to constructor')
@@ -160,7 +169,7 @@ class Reader(BaseReader, StructuredReader):
 
         # this is an opporunity to save interpolators to pickle to save sim time
         self.save_interpolator = save_interpolator
-        self.interpolator_path = interpolator_path or f'{self.name}_interpolators'
+        self.interpolator_filename = interpolator_filename or f'{self.name}_interpolators'
 
         if gridfile is not None:  # Merging gridfile dataset with main dataset
             gf = xr.open_dataset(gridfile)
@@ -200,9 +209,12 @@ class Reader(BaseReader, StructuredReader):
                 self.hc = self.Dataset.variables['hc'][:]
             except:
                 self.hc = self.Dataset.variables['hc'].data  # scalar
+            else:
+                self.hc = None
 
             self.num_layers = len(self.sigma)
         else:
+            logger.warning("2D dataset, so deleting u and v from ROMS_variable_mapping")
             self.num_layers = 1
             self.ROMS_variable_mapping['ubar'] = 'x_sea_water_velocity'
             self.ROMS_variable_mapping['vbar'] = 'y_sea_water_velocity'
@@ -293,7 +305,7 @@ class Reader(BaseReader, StructuredReader):
         If this mask is 2D, read it in this one time and use going forward in simulation. If 3D,
         will read in parts of the mask each loop.
         """
-        if not hasattr(self, '_mask_rho'):
+        if self._mask_rho is None:
             if 'wetdry_mask_rho' in self.Dataset.data_vars:
                 self._mask_rho = self.Dataset.variables['wetdry_mask_rho']
                 logger.info("Using wetdry_mask_rho for mask_rho")
@@ -301,7 +313,7 @@ class Reader(BaseReader, StructuredReader):
                 # Read landmask for whole domain, for later re-use
                 self._mask_rho = self.Dataset.variables['mask_rho'][:]
                 # load in once if static mask
-                if hasattr(self._mask_rho, "chunks"):  # to see if dask array
+                if self._mask_rho.chunks is not None:  # to see if dask array
                     self._mask_rho = self._mask_rho.compute()
                 logger.info("Using mask_rho for mask_rho")
         return self._mask_rho
@@ -314,7 +326,7 @@ class Reader(BaseReader, StructuredReader):
         If this mask is 2D, read it in this one time and use going forward in simulation. If 3D,
         will read in parts of the mask each loop.
         """
-        if not hasattr(self, '_mask_u'):
+        if self._mask_u is None:
             if 'wetdry_mask_u' in self.Dataset.data_vars:
                 self._mask_u = self.Dataset.variables['wetdry_mask_u']
                 logger.info("Using wetdry_mask_u for mask_u")
@@ -322,7 +334,7 @@ class Reader(BaseReader, StructuredReader):
                 # Read landmask for whole domain, for later re-use
                 self._mask_u = self.Dataset.variables['mask_u'][:]
                 # load in once if static mask
-                if hasattr(self._mask_u, "chunks"):  # to see if dask array
+                if self._mask_u.chunks is not None:  # to see if dask array
                     self._mask_u = self._mask_u.compute()
                 logger.info("Using mask_u for mask_u")
         return self._mask_u
@@ -335,7 +347,7 @@ class Reader(BaseReader, StructuredReader):
         If this mask is 2D, read it in this one time and use going forward in simulation. If 3D,
         will read in parts of the mask each loop.
         """
-        if not hasattr(self, '_mask_v'):
+        if self._mask_v is None:
             if 'wetdry_mask_v' in self.Dataset.data_vars:
                 self._mask_v = self.Dataset.variables['wetdry_mask_v']
                 logger.info("Using wetdry_mask_v for mask_v")
@@ -343,7 +355,7 @@ class Reader(BaseReader, StructuredReader):
                 # Read landmask for whole domain, for later re-use
                 self._mask_v = self.Dataset.variables['mask_v'][:]
                 # load in once if static mask
-                if hasattr(self._mask_v, "chunks"):  # to see if dask array
+                if self._mask_v.chunks is not None:  # to see if dask array
                     self._mask_v = self._mask_v.compute()
                 logger.info("Using mask_v for mask_v")
         return self._mask_v
@@ -355,11 +367,10 @@ class Reader(BaseReader, StructuredReader):
             requested_variables, time, x, y, z)
 
         # land_binary_mask should be based on the rho grid
-        if 'land_binary_mask' in requested_variables and not hasattr(self, 'land_binary_mask'):
+        if 'land_binary_mask' in requested_variables and self.land_binary_mask is None:
             self.land_binary_mask = 1 - self.mask_rho
 
-        if 'sea_floor_depth_below_sea_level' in requested_variables and not hasattr(
-                    self, 'sea_floor_depth_below_sea_level'):
+        if 'sea_floor_depth_below_sea_level' in requested_variables and self.sea_floor_depth_below_sea_level is None:
             self.sea_floor_depth_below_sea_level = self.Dataset.variables['h'][:]
 
         # If one vector component is requested, but not the other
@@ -381,7 +392,7 @@ class Reader(BaseReader, StructuredReader):
             z = np.atleast_1d(0)
 
         # Find horizontal indices corresponding to requested x and y
-        if hasattr(self, 'clipped'):
+        if self.clipped is not None:
             clipped = self.clipped
         else: clipped = 0
         indx = np.floor((x-self.xmin)/self.delta_x).astype(int) + clipped
@@ -400,18 +411,18 @@ class Reader(BaseReader, StructuredReader):
                             np.min([indy.max()+buffer, self.lon.shape[0]-1]))
 
         # Find depth levels covering all elements
-        if z.min() == 0 or not hasattr(self, 'hc'):
+        if z.min() == 0 or self.hc is None:
             indz = self.num_layers - 1  # surface layer
             variables['z'] = 0
 
         else:
             # Find the range of indices covering given z-values
-            if not hasattr(self, 'sea_floor_depth_below_sea_level'):
+            if self.sea_floor_depth_below_sea_level is None:
                 logger.debug('Reading sea floor depth...')
                 self.sea_floor_depth_below_sea_level = \
                     self.Dataset.variables['h'][:]
 
-            if not hasattr(self, 'z_rho_tot'):
+            if self.z_rho_tot is None:
                 Htot = self.sea_floor_depth_below_sea_level
                 self.z_rho_tot = depth.sdepth(Htot, self.hc, self.Cs_r,
                                               Vtransform=self.Vtransform)
@@ -510,7 +521,7 @@ class Reader(BaseReader, StructuredReader):
                         M = self.sea_floor_depth_below_sea_level.shape[0]
                         N = self.sea_floor_depth_below_sea_level.shape[1]
                         O = len(self.z_rho_tot)
-                        if not hasattr(self, 's2z_A'):
+                        if self.s2z_A is None:
                             logger.debug('Calculating sigma2z-coefficients for whole domain')
                             starttime = datetime.now()
                             dummyvar = np.ones((O, M, N))
@@ -633,7 +644,7 @@ class Reader(BaseReader, StructuredReader):
             'sea_ice_x_velocity' not in self.do_not_rotate and \
             'x_wind' not in self.do_not_rotate:
             # We must rotate current vectors
-            if not hasattr(self, 'angle_xi_east'):
+            if self.angle_xi_east is None:
                 if 'angle' in self.Dataset.variables:
                     logger.debug('Reading angle between xi and east...')
                     self.angle_xi_east = self.Dataset.variables['angle'][:]

--- a/opendrift/readers/reader_schism_native.py
+++ b/opendrift/readers/reader_schism_native.py
@@ -212,8 +212,8 @@ class Reader(BaseReader,UnstructuredReader):
                 self.numy = var.shape[0]
             if standard_name == 'depth' or axis == 'Z':
                 var_data = var.values
-                if 'positive' not in var.ncattrs() or \
-                        var.__dict__['positive'] == 'up':
+                if 'positive' not in var.attrs or \
+                        var.attrs['positive'] == 'up':
                     self.z = var_data
                 else:
                     self.z = -var_data


### PR DESCRIPTION
there was a bug writing data to the netCDF file. In some rare situations, step 100 (the default) is skipped, leading to an error as the buffer_limit _length is exceeded in the next step.

The following code produce the error : 
`from datetime import datetime, timedelta
from opendrift.models.oceandrift import OceanDrift

o = OceanDrift(loglevel=20)

o.set_config("general:use_auto_landmask", False)
o.set_config("environment:constant:land_binary_mask", 0)
o.set_config("drift:max_age_seconds", 100)
start_time = datetime(2024, 1, 1)

o.seed_elements(lon=3, lat=60, time=start_time)
o.seed_elements(lon=3, lat=60, time=start_time + timedelta(hours=1) * 7)
o.seed_elements(lon=3, lat=60, time=start_time + timedelta(hours=1) * 100)

o.run(
    steps=200,
    export_buffer_length=5,
    outfile="test.nc",
    time_step=3600,
    time_step_output=3600 * 2,
)`