### PR TITLE
state_to_buffer save

### DIFF
--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -1971,12 +1971,12 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
                 if self.num_elements_active(
                 ) == 0 and self.num_elements_scheduled() > 0:
-                    self.steps_calculation += 1
                     logger.info(
                         'No active but %s scheduled elements, skipping timestep %s (%s)'
                         % (self.num_elements_scheduled(),
-                           self.steps_calculation, self.time))
+                           self.steps_calculation + 1 , self.time)) # LH correction : +1 to be consistent with the line 2048
                     self.state_to_buffer()  # Append status to history array
+                    self.steps_calculation += 1  # LH correction : Move from line 2020 to 2030 to propagate the step calculation after the state_to_buffer and to be consistent with the line 2106
                     if self.time is not None:
                         self.time = self.time + self.time_step
                     continue


### PR DESCRIPTION
there was a bug writing data to the netCDF file. In some rare situations, step 100 (the default) is skipped, leading to an error as the buffer_limit _length is exceeded in the next step.

The following code produce the error :
`from datetime import datetime, timedelta
from opendrift.models.oceandrift import OceanDrift

o = OceanDrift(loglevel=20)

o.set_config("general:use_auto_landmask", False)
o.set_config("environment:constant:land_binary_mask", 0)
o.set_config("drift:max_age_seconds", 100)
start_time = datetime(2024, 1, 1)

o.seed_elements(lon=3, lat=60, time=start_time)
o.seed_elements(lon=3, lat=60, time=start_time + timedelta(hours=1) * 7)
o.seed_elements(lon=3, lat=60, time=start_time + timedelta(hours=1) * 100)

o.run(
steps=200,
export_buffer_length=5,
outfile="test.nc",
time_step=3600,
time_step_output=3600 * 2,
)`