### PR TITLE
IO module for parquet

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -34,4 +34,3 @@ dependencies:
   - pip
   - pip:
     - motuclient
-    - pytest-sphinx

--- a/opendrift/export/io_parquet.py
+++ b/opendrift/export/io_parquet.py
@@ -1,0 +1,67 @@
+import sys
+import os
+from datetime import datetime, timedelta
+import logging
+
+logging.captureWarnings(True)
+logger = logging.getLogger(__name__)
+import string
+from shutil import move
+
+import numpy as np
+import pandas as pd
+from opendrift.models.basemodel import Mode
+
+def init(self, filename):
+
+    self.outfile = filename
+    dummy_data = {
+        k: pd.Series([], dtype=t) for k, (t, _) in self.history.dtype.fields.items()
+    }
+    dummy_data["time"] = pd.Series([], dtype="datetime64[ns]")
+    df = pd.DataFrame(dummy_data)
+    df.to_parquet(self.outfile, engine="fastparquet")
+
+
+def write_buffer(self):
+    num_steps_to_export = self.steps_output - self.steps_exported
+
+    data = {
+        k: self.history[k][:, 0:num_steps_to_export][
+            ~self.history[k].mask[:, 0:num_steps_to_export]
+        ]  # automatically flattens array
+        for k in self.history.dtype.fields
+    }
+
+    times = [
+        self.start_time + n * self.time_step_output
+        for n in range(self.steps_exported, self.steps_output)
+    ]
+
+    _arr_template = self.history["ID"][:, 0:num_steps_to_export]
+    time_arr = np.repeat([times], _arr_template.shape[0], axis=0)
+    data["time"] = time_arr[~_arr_template.mask]  # automatically flattens array
+
+    df = pd.DataFrame(data)
+    df.to_parquet(self.outfile, engine="fastparquet", append=True)
+
+    logger.info("Wrote %s steps to file %s" % (num_steps_to_export, self.outfile))
+    self.history.mask = True  # Reset history array, for new data
+    self.steps_exported = self.steps_exported + num_steps_to_export
+
+
+def close(self):
+    logger.warn("`.close` not strictly needed...?")
+
+def import_file(self, filename, times=None, elements=None, load_history=True):
+    """Create OpenDrift object from imported file.
+    This reimport is potentially very costly anyway 
+    """
+    logger.info("Skipping reimport")
+    return self
+
+def import_file_xarray(self, filename, times=None, elements=None, load_history=True):
+    """Create OpenDrift object from file
+    Odd if this I/O backend specific feature were required for all of opendrift to run
+    """
+    raise NotImplementedError("wontfix")

--- a/opendrift/export/io_parquet.py
+++ b/opendrift/export/io_parquet.py
@@ -51,7 +51,7 @@ def write_buffer(self):
 
 
 def close(self):
-    logger.warn("`.close` not strictly needed...?")
+    logger.warning("`.close` not strictly needed...?")
 
 def import_file(self, filename, times=None, elements=None, load_history=True):
     """Create OpenDrift object from imported file.

--- a/tests/models/test_io.py
+++ b/tests/models/test_io.py
@@ -42,6 +42,7 @@ class TestIO(unittest.TestCase):
     """Tests for file io"""
 
     def test_io_parquet(self):
+        outfile = "test_io_parquet.nc"
         o = OceanDrift(
             loglevel=30,
             iomodule="parquet",
@@ -57,10 +58,10 @@ class TestIO(unittest.TestCase):
             steps=10,
             time_step=timedelta(minutes=30),
             time_step_output=timedelta(minutes=30),
-            outfile="test_io_parquet.nc",
+            outfile=outfile,
             export_buffer_length=2,
         )
-        os.remove("test_time_step30.nc")
+        os.remove(outfile)
 
 
 if __name__ == "__main__":

--- a/tests/models/test_io.py
+++ b/tests/models/test_io.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This file is part of OpenDrift.
+#
+# OpenDrift is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 2
+#
+# OpenDrift is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenDrift.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Copyright 2015, Knut-Frode Dagestad, MET Norway
+
+import unittest
+import pytest
+from datetime import datetime, timedelta
+import os
+import inspect
+
+import numpy as np
+
+from opendrift.readers import reader_ArtificialOceanEddy
+from opendrift.readers import reader_global_landmask
+from opendrift.readers import reader_netCDF_CF_generic
+from opendrift.readers import reader_ROMS_native
+from opendrift.readers import reader_oscillating
+from opendrift.models.oceandrift import OceanDrift
+from opendrift.models.basemodel import Mode, WrongMode
+from opendrift.models.openoil import OpenOil
+from opendrift.models.leeway import Leeway
+from opendrift.models.pelagicegg import PelagicEggDrift
+from opendrift.models.plastdrift import PlastDrift
+
+
+class TestIO(unittest.TestCase):
+    """Tests for file io"""
+
+    def test_io_parquet(self):
+        o = OceanDrift(
+            loglevel=30,
+            iomodule="parquet",
+        )
+        norkyst = reader_netCDF_CF_generic.Reader(
+            o.test_data_folder()
+            + "16Nov2015_NorKyst_z_surface/norkyst800_subset_16Nov2015.nc"
+        )
+        landmask = reader_global_landmask.Reader()
+        o.add_reader([landmask, norkyst])
+        o.seed_elements(4.96, 60.1, radius=10, number=10, time=norkyst.start_time)
+        o.run(
+            steps=10,
+            time_step=timedelta(minutes=30),
+            time_step_output=timedelta(minutes=30),
+            outfile="test_io_parquet.nc",
+            export_buffer_length=2,
+        )
+        os.remove("test_time_step30.nc")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
For long-running simulations with limited particle lifetimes, in-memory sizes of netcdf arrays become quite large. Also, (at least for me) the first operation I do with the netcdf files usually is `xr.open_dataset(...).to_dataframe()`.This is a first draft that writes directly to a tabular format.