### PR TITLE
Updates to ROMS zeta, seafloor checks, tests

### DIFF
--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -694,8 +694,25 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             return
         if 'sea_floor_depth_below_sea_level' not in self.env.priority_list:
             return
+
+        if not hasattr(self, 'environment') or not hasattr(
+                self.environment, 'sea_surface_height'):
+            logger.warning('Seafloor check not being run because sea_surface_height is missing. '
+                           'This will happen the first time the function is run but if it happens '
+                           'subsequently there is probably a problem.')
+            return
+
+        # the shape of these is different than the original arrays
+        # because it is for active drifters
         sea_floor_depth = self.sea_floor_depth()
-        below = np.where(self.elements.z < -sea_floor_depth)[0]
+        sea_surface_height = self.sea_surface_height()
+
+        # Check if any elements are below sea floor
+        # But remember that the water column is the sea floor depth + sea surface height + parameter Dcrit
+        Dcrit = self.get_config('general:seafloor_action_dcrit')
+        ibelow = self.elements.z < -(sea_floor_depth + sea_surface_height + Dcrit)
+        below = np.where(ibelow)[0]
+
         if len(below) == 0:
             logger.debug('No elements hit seafloor.')
             return
@@ -705,8 +722,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             logger.debug('Lifting %s elements to seafloor.' % len(below))
             self.elements.z[below] = -sea_floor_depth[below]
         elif i == 'deactivate':
-            self.deactivate_elements(self.elements.z < -sea_floor_depth,
-                                     reason='seafloor')
+            self.deactivate_elements(ibelow, reason='seafloor')
             self.elements.z[below] = -sea_floor_depth[below]
         elif i == 'previous':  # Go back to previous position (in water)
             logger.warning('%s elements hit seafloor, '

--- a/opendrift/models/chemicaldrift.py
+++ b/opendrift/models/chemicaldrift.py
@@ -93,6 +93,7 @@ class ChemicalDrift(OceanDrift):
     required_variables = {
         'x_sea_water_velocity': {'fallback': None},
         'y_sea_water_velocity': {'fallback': None},
+        'sea_surface_height': {'fallback': 0},
         'x_wind': {'fallback': 0},
         'y_wind': {'fallback': 0},
         'land_binary_mask': {'fallback': None},

--- a/opendrift/models/larvalfish.py
+++ b/opendrift/models/larvalfish.py
@@ -68,6 +68,7 @@ class LarvalFish(OceanDrift):
     required_variables = {
         'x_sea_water_velocity': {'fallback': 0},
         'y_sea_water_velocity': {'fallback': 0},
+        'sea_surface_height': {'fallback': 0},
         'sea_surface_wave_significant_height': {'fallback': 0},
         'x_wind': {'fallback': 0},
         'y_wind': {'fallback': 0},

--- a/opendrift/models/model_template.py
+++ b/opendrift/models/model_template.py
@@ -83,6 +83,7 @@ class ModelTemplate(OceanDrift):
     required_variables = {
         'x_sea_water_velocity': {'fallback': 0},
         'y_sea_water_velocity': {'fallback': 0},
+        'sea_surface_height': {'fallback': 0},
         'x_wind': {'fallback': 0, 'important': False},
         'y_wind': {'fallback': 0, 'important': False},
         'ocean_vertical_diffusivity': {'fallback': 0.02, 'important': False, 'profiles': True},

--- a/opendrift/models/oceandrift.py
+++ b/opendrift/models/oceandrift.py
@@ -69,6 +69,7 @@ class OceanDrift(OpenDriftSimulation):
     required_variables = {
         'x_sea_water_velocity': {'fallback': 0},
         'y_sea_water_velocity': {'fallback': 0},
+        'sea_surface_height': {'fallback': 0},
         'x_wind': {'fallback': 0},
         'y_wind': {'fallback': 0},
         'upward_sea_water_velocity': {'fallback': 0},
@@ -157,6 +158,10 @@ class OceanDrift(OpenDriftSimulation):
             'general:seafloor_action': {'type': 'enum', 'default': 'lift_to_seafloor',
                 'enum': ['none', 'lift_to_seafloor', 'deactivate', 'previous'],
                 'description': '"deactivate": elements are deactivated; "lift_to_seafloor": elements are lifted to seafloor level; "previous": elements are moved back to previous position; "none"; seafloor is ignored.',
+                'level': CONFIG_LEVEL_ADVANCED},
+            'general:seafloor_action_dcrit': {'type': 'float', 'default': 0.0,
+                'min': 0.0, 'max': 10000, 'units': 'm',
+                'description': 'This parameter represents the amount of water left in a grid cell to keep it wet in a wet/dry simulation for numerical stability. The condition checked for seafloor_action is z < -(sea_floor_depth + sea_surface_height + `general:seafloor_action_dcrit`. It is 0 by default to assume that a wet/dry case is not being run, however, if it is and the correct value is not known 0.1 is a good default to use.',
                 'level': CONFIG_LEVEL_ADVANCED},
             'drift:truncate_ocean_model_below_m': {'type': 'float', 'default': None,
                 'min': 0, 'max': 10000, 'units': 'm',
@@ -489,8 +494,10 @@ class OceanDrift(OpenDriftSimulation):
 
         dt_mix = self.get_config('vertical_mixing:timestep')
 
-        # minimum height/maximum depth for each particle
-        Zmin = -1.*self.environment.sea_floor_depth_below_sea_level
+        # minimum height/maximum depth for each particle accouting also for
+        # the sea surface height and the critical/min wet cell depth
+        Dcrit = self.get_config('general:seafloor_action_dcrit')
+        Zmin = -1.*(self.environment.sea_floor_depth_below_sea_level + self.environment.sea_surface_height + Dcrit)
 
         # Eventual model specific preparions
         self.prepare_vertical_mixing()
@@ -609,6 +616,7 @@ class OceanDrift(OpenDriftSimulation):
                 self.elements.z[reflect] = -self.elements.z[reflect]
 
             # Reflect elements going below seafloor
+            # Zmin accounts for sea_surface_height
             bottom = np.where(np.logical_and(self.elements.z < Zmin, self.elements.moving == 1))
             if len(bottom[0]) > 0:
                 logger.debug('%s elements penetrated seafloor, lifting up' % len(bottom[0]))
@@ -629,7 +637,7 @@ class OceanDrift(OpenDriftSimulation):
             # Let particles stick to bottom
             bottom = np.where(self.elements.z < Zmin)
             if len(bottom[0]) > 0:
-                logger.debug('%s elements reached seafloor, set to bottom' % len(bottom[0]))
+                logger.debug('%s elements reached seafloor, interacting with bottom' % len(bottom[0]))
                 self.interact_with_seafloor()
                 self.bottom_interaction(Zmin)
 

--- a/opendrift/models/oceandrift.py
+++ b/opendrift/models/oceandrift.py
@@ -416,13 +416,15 @@ class OceanDrift(OpenDriftSimulation):
             self.elements.z[in_ocean] = np.minimum(0,
                 self.elements.z[in_ocean] + self.elements.terminal_velocity[in_ocean] * self.time_step.total_seconds())
 
-        # check for minimum height/maximum depth for each particle
-        Zmin = -1.*self.environment.sea_floor_depth_below_sea_level
+        # check for minimum height/maximum depth for each particle accouting also for
+        # the sea surface height and the critical/min wet cell depth
+        Dcrit = self.get_config('general:seafloor_action_dcrit')
+        Zmin = -1.*(self.environment.sea_floor_depth_below_sea_level + self.environment.sea_surface_height + Dcrit)
 
         # Let particles stick to bottom
         bottom = np.where(self.elements.z < Zmin)
         if len(bottom[0]) > 0:
-            logger.debug('%s elements reached seafloor, set to bottom' % len(bottom[0]))
+            logger.debug('%s elements reached seafloor, interacting with bottom' % len(bottom[0]))
             self.interact_with_seafloor()
             self.bottom_interaction(Zmin)
 

--- a/opendrift/models/openberg.py
+++ b/opendrift/models/openberg.py
@@ -59,6 +59,7 @@ class OpenBerg(OceanDrift):
     required_variables = {
         'x_sea_water_velocity': {'fallback': None},
         'y_sea_water_velocity': {'fallback': None},
+        'sea_surface_height': {'fallback': 0},
         'sea_floor_depth_below_sea_level': {'fallback': 10000},
         'x_wind': {'fallback': None},
         'y_wind': {'fallback': None},

--- a/opendrift/models/openhns.py
+++ b/opendrift/models/openhns.py
@@ -109,6 +109,7 @@ class OpenHNS(OceanDrift):
         'y_sea_water_velocity': {
             'fallback': None
         },
+        'sea_surface_height': {'fallback': 0},
         'x_wind': {
             'fallback': None
         },

--- a/opendrift/models/openoil/openoil.py
+++ b/opendrift/models/openoil/openoil.py
@@ -229,6 +229,7 @@ class OpenOil(OceanDrift):
         'y_wind': {
             'fallback': None
         },
+        'sea_surface_height': {'fallback': 0},
         'upward_sea_water_velocity': {
             'fallback': 0,
             'important': False

--- a/opendrift/models/pelagicegg.py
+++ b/opendrift/models/pelagicegg.py
@@ -59,6 +59,7 @@ class PelagicEggDrift(OceanDrift):
     required_variables = {
         'x_sea_water_velocity': {'fallback': 0},
         'y_sea_water_velocity': {'fallback': 0},
+        'sea_surface_height': {'fallback': 0},
         'sea_surface_wave_significant_height': {'fallback': 0},
         'sea_ice_area_fraction': {'fallback': 0},
         'x_wind': {'fallback': 0},

--- a/opendrift/models/physics_methods.py
+++ b/opendrift/models/physics_methods.py
@@ -1114,6 +1114,25 @@ class PhysicsMethods:
                 env['sea_floor_depth_below_sea_level'].astype('float32')
         return sea_floor_depth
 
+    def sea_surface_height(self):
+        '''Sea surface height (positive/negative) for presently active elements'''
+
+        if hasattr(self, 'environment') and \
+                hasattr(self.environment, 'sea_surface_height'):
+            if len(self.environment.sea_surface_height) == \
+                    self.num_elements_active():
+                sea_surface_height = \
+                    self.environment.sea_surface_height
+        if 'sea_surface_height' not in locals():
+            env, env_profiles, missing = \
+                self.env.get_environment(['sea_surface_height'],
+                                     time=self.time, lon=self.elements.lon,
+                                     lat=self.elements.lat,
+                                     z=0*self.elements.lon, profiles=None)
+            sea_surface_height = \
+                env['sea_surface_height'].astype('float32')
+        return sea_surface_height
+
 
 def wind_drag_coefficient(windspeed):
     '''Large and Pond (1981), J. Phys. Oceanog., 11, 324-336.'''

--- a/opendrift/models/plastdrift.py
+++ b/opendrift/models/plastdrift.py
@@ -44,6 +44,7 @@ class PlastDrift(OceanDrift):
     required_variables = {
         'x_sea_water_velocity': {'fallback': 0},
         'y_sea_water_velocity': {'fallback': 0},
+        'sea_surface_height': {'fallback': 0},
         'sea_surface_wave_stokes_drift_x_velocity': {'fallback': 0},
         'sea_surface_wave_stokes_drift_y_velocity': {'fallback': 0},
         'sea_surface_wave_significant_height': {'fallback': 0},

--- a/opendrift/models/radionuclides.py
+++ b/opendrift/models/radionuclides.py
@@ -75,6 +75,7 @@ class RadionuclideDrift(OceanDrift):
     required_variables = {
         'x_sea_water_velocity': {'fallback': None},
         'y_sea_water_velocity': {'fallback': None},
+        'sea_surface_height': {'fallback': 0},
         'x_wind': {'fallback': 0},
         'y_wind': {'fallback': 0},
         'land_binary_mask': {'fallback': None},

--- a/opendrift/models/sealice.py
+++ b/opendrift/models/sealice.py
@@ -84,6 +84,7 @@ class SeaLice(OceanDrift):
     required_variables = {
         'x_sea_water_velocity': {'fallback': 0},
         'y_sea_water_velocity': {'fallback': 0},
+        'sea_surface_height': {'fallback': 0},
         # 'sea_surface_wave_significant_height': {'fallback': 0},
         # 'x_wind': {'fallback': 0},
         # 'y_wind': {'fallback': 0},

--- a/opendrift/models/sedimentdrift.py
+++ b/opendrift/models/sedimentdrift.py
@@ -45,6 +45,7 @@ class SedimentDrift(OceanDrift):
     required_variables = {
         'x_sea_water_velocity': {'fallback': 0},
         'y_sea_water_velocity': {'fallback': 0},
+        'sea_surface_height': {'fallback': 0},
         'upward_sea_water_velocity': {'fallback': 0},
         'x_wind': {'fallback': 0},
         'y_wind': {'fallback': 0},

--- a/opendrift/readers/basereader/consts.py
+++ b/opendrift/readers/basereader/consts.py
@@ -17,7 +17,7 @@ standard_names = {
                       '(northwards if projection is lonlat/Mercator)'},
     'land_binary_mask': {'valid_min': 0, 'valid_max': 1,
                          'long_name': '1 is land, 0 is sea'},
-    'sea_floor_depth_below_sea_level': {'valid_min': -10, 'valid_max': 12000,
+    'sea_floor_depth_below_sea_level': {'valid_min': -20, 'valid_max': 12000,
                          'long_name': 'Depth of seafloor'},
     'ocean_vertical_diffusivity': {'valid_min': 0, 'valid_max': 1}}
 

--- a/opendrift/readers/reader_ROMS_native.py
+++ b/opendrift/readers/reader_ROMS_native.py
@@ -82,11 +82,11 @@ class Reader(BaseReader, StructuredReader):
         self._mask_u = None
         self._mask_v = None
         self._zeta = None
+        self._angle = None
         self.land_binary_mask = None
         self.sea_floor_depth_below_sea_level = None
         self.z_rho_tot = None
         self.s2z_A = None
-        self.angle_xi_east = None
 
         if filename is None:
             raise ValueError('Need filename as argument to constructor')
@@ -153,7 +153,7 @@ class Reader(BaseReader, StructuredReader):
                         dropvars = [v for v in ds.variables if v not in
                                     list(self.ROMS_variable_mapping.keys()) + gls_param +
                                     ['ocean_time', 'time', 'bulk_time', 's_rho',
-                                     'Cs_r', 'hc', 'angle', 'Vtransform']
+                                     'Cs_r', 'hc', 'Vtransform']
                                     and v[0:3] not in ['lon', 'lat', 'mas']]
                         logger.debug('Dropping variables: %s' % dropvars)
                         ds = ds.drop_vars(dropvars)
@@ -230,7 +230,7 @@ class Reader(BaseReader, StructuredReader):
             self.lat = self.lat.data
             if self.lat.ndim == 1:
                 self.lon, self.lat = np.meshgrid(self.lon, self.lat)
-                self.angle_xi_east = 0
+                # self.angle_xi_east = 0  # this was moved to the angle property
         else:
             raise ValueError(filename + ' does not contain lon/lat '
                              'arrays, please supply a grid-file: "gridfile=<grid_file>"')
@@ -372,9 +372,23 @@ class Reader(BaseReader, StructuredReader):
                 self._zeta = np.zeros(self.mask_rho.shape)
                 logger.info("No zeta found, using 0 array for sea surface height")
         return self._zeta        
+    
+    @property
+    def angle(self):
+        """Grid angle if curvilinear."""
+        if self._angle is None:
+            if 'lat_rho' in self.Dataset.variables and self.lat.ndim == 1:
+                self._angle = 0
+            elif 'angle' in self.Dataset.data_vars:
+                self._angle = self.Dataset.variables['angle']
+                logger.info("Using angle from Dataset.")
+
+            if self._angle is None:
+                raise ValueError('No angle between xi and east found')
+        return self._angle
 
     def get_variables(self, requested_variables, time=None,
-                      x=None, y=None, z=None):
+                      x=None, y=None, z=None, testing=False):
         start_time = datetime.now()
         requested_variables, time, x, y, z, outside = self.check_arguments(
             requested_variables, time, x, y, z)
@@ -483,17 +497,22 @@ class Reader(BaseReader, StructuredReader):
         # define another set of indices
         itzxy = (indxTime, indz, indy, indx)
             
-        def get_mask(mask_name, imask):
-            if mask_name in masks_for_loop:
-                mask = masks_for_loop[mask_name]
+        def get_mask(mask_name, imask, masks_store):
+            if mask_name in masks_store:
+                mask = masks_store[mask_name]
             else:
                 mask = getattr(self, mask_name)[imask]
             return mask, mask_name
 
-        masks_for_loop = {}  # To store maskes for various grids
+        masks_store = {}  # To store masks for various grids
         for par in requested_variables:
             varname = [name for name, cf in
                        self.ROMS_variable_mapping.items() if cf == par]
+            if len(varname) > 1:
+                raise ValueError("Multiple variables exist with standard name and "
+                                 "are present in reader. Either remove the duplicate mapping "
+                                 "or remove the variable from the reader."
+                                 "Variables: " + str(varname))
             var = self.Dataset.variables[varname[0]]
 
             if par == 'land_binary_mask':
@@ -518,15 +537,15 @@ class Reader(BaseReader, StructuredReader):
                 # make sure that var has matching horizontal dimensions with the mask
                 # make sure coord names also match
                 if self.mask_rho.shape[-2:] == var.shape[-2:] and self.mask_rho.dims[-2:] == var.dims[-2:]:
-                    mask, mask_name = get_mask("mask_rho", imask)
+                    mask, mask_name = get_mask("mask_rho", imask, masks_store)
                 elif self.mask_u.shape[-2:] == var.shape[-2:] and self.mask_u.dims[-2:] == var.dims[-2:]:
-                    mask, mask_name = get_mask("mask_u", imask)
+                    mask, mask_name = get_mask("mask_u", imask, masks_store)
                 elif self.mask_v.shape[-2:] == var.shape[-2:] and self.mask_v.dims[-2:] == var.dims[-2:]:
-                    mask, mask_name = get_mask("mask_v", imask)
+                    mask, mask_name = get_mask("mask_v", imask, masks_store)
                 else:
                     raise Exception('No mask found for ' + par)
 
-                masks_for_loop[mask_name] = np.asarray(mask)
+                masks_store[mask_name] = np.asarray(mask)
                 mask = np.asarray(mask)
 
                 if mask.min() == 0:
@@ -659,29 +678,24 @@ class Reader(BaseReader, StructuredReader):
         variables['y'] = variables['y'].astype(np.float32)
         variables['time'] = nearestTime
 
-        if 'x_sea_water_velocity' in variables.keys() or \
-            'sea_ice_x_velocity' in variables.keys() or \
-            'x_wind' in variables.keys() and \
-            'x_sea_water_velocity' not in self.do_not_rotate and \
-            'sea_ice_x_velocity' not in self.do_not_rotate and \
-            'x_wind' not in self.do_not_rotate:
-            # We must rotate current vectors
-            if self.angle_xi_east is None:
-                if 'angle' in self.Dataset.variables:
-                    logger.debug('Reading angle between xi and east...')
-                    self.angle_xi_east = self.Dataset.variables['angle'][:]
-            if isinstance(self.angle_xi_east, int):
-                rad = self.angle_xi_east
+        if 'x_sea_water_velocity' in variables.keys() and \
+            'x_sea_water_velocity' not in self.do_not_rotate:
+            if isinstance(self.angle, int):
+                rad = self.angle
             else:
-                rad = self.angle_xi_east[indy, indx]
-                rad = np.ma.asarray(rad)
-            if 'x_sea_water_velocity' in variables.keys() and \
-                    'x_sea_water_velocity' not in self.do_not_rotate:
-                variables['x_sea_water_velocity'], \
-                    variables['y_sea_water_velocity'] = rotate_vectors_angle(
-                        variables['x_sea_water_velocity'],
-                        variables['y_sea_water_velocity'], rad)
-                logger.debug('Rotated x_sea_water_velocity and y_sea_water_velocity')
+                rad = np.ma.asarray(self.angle[indy, indx])
+            variables['x_sea_water_velocity'], \
+                variables['y_sea_water_velocity'] = rotate_vectors_angle(
+                    variables['x_sea_water_velocity'],
+                    variables['y_sea_water_velocity'], rad)
+            logger.debug('Rotated x_sea_water_velocity and y_sea_water_velocity')
+        
+        if 'sea_ice_x_velocity' in variables.keys() and \
+            'sea_ice_x_velocity' not in self.do_not_rotate:
+            if isinstance(self.angle, int):
+                rad = self.angle
+            else:
+                rad = np.ma.asarray(self.angle[indy, indx])
             if 'sea_ice_x_velocity' in variables.keys() and \
                     'sea_ice_x_velocity' not in self.do_not_rotate:
                 variables['sea_ice_x_velocity'], \
@@ -689,6 +703,12 @@ class Reader(BaseReader, StructuredReader):
                         variables['sea_ice_x_velocity'],
                         variables['sea_ice_y_velocity'], rad)
                 logger.debug('Rotated sea_ice_x_velocity and sea_ice_y_velocity')
+        
+        if 'x_wind' in variables.keys() and 'x_wind' not in self.do_not_rotate:
+            if isinstance(self.angle, int):
+                rad = self.angle
+            else:
+                rad = np.ma.asarray(self.angle[indy, indx])
             if 'x_wind' in variables.keys() and \
                     'x_wind' not in self.do_not_rotate:
                 variables['x_wind'], \
@@ -703,7 +723,10 @@ class Reader(BaseReader, StructuredReader):
 
         logger.debug('Time for ROMS native reader: ' + str(datetime.now()-start_time))
 
-        return variables
+        if testing:
+            return variables, masks_store
+        else:
+            return variables
 
 
 def rotate_vectors_angle(u, v, radians):

--- a/tests/models/test_run.py
+++ b/tests/models/test_run.py
@@ -390,9 +390,9 @@ class TestRun(unittest.TestCase):
             o.time = time
             o.time_step = timedelta(hours=2)
             o.release_elements()
-            o.environment = np.array(np.ones(N)*100,
-                            dtype=[('sea_floor_depth_below_sea_level',
-                                    np.float32)]).view(np.recarray)
+            o.environment = np.array([(100, 0) for _ in range(N)],
+                         dtype=[('sea_floor_depth_below_sea_level', np.float32),
+                                ('sea_surface_height', np.float32)]).view(np.recarray)
             o.environment_profiles = { 'z': z, 'ocean_vertical_diffusivity':
                                       np.tile(diffusivity, (N, 1)).T}
             o.env.finalize()

--- a/tests/models/test_stranding.py
+++ b/tests/models/test_stranding.py
@@ -50,15 +50,15 @@ class TestStranding(unittest.TestCase):
         self.assertEqual(o.elements_deactivated.status.min(), 1)
         self.assertEqual(o.elements_deactivated.status.max(), 1)
         self.assertEqual(o.num_elements_scheduled(), 0)
-        self.assertEqual(o.num_elements_active(), 77)
+        self.assertEqual(o.num_elements_active(), 82)
         self.assertEqual(o.num_elements_activated(), 100)
-        self.assertEqual(o.num_elements_deactivated(), 23)
+        self.assertEqual(o.num_elements_deactivated(), 18)
         self.assertEqual(o.num_elements_total(), 100)
 
         # Check calculated trajectory lengths and speeds
         total_length, distances, speeds = o.get_trajectory_lengths()
-        self.assertAlmostEqual(total_length.max(), 14974.8, 1)
-        self.assertAlmostEqual(total_length.min(), 1222.3, 1)
+        self.assertAlmostEqual(total_length.max(), 15719.5, 1)
+        self.assertAlmostEqual(total_length.min(), 1225.2, 1)
         self.assertAlmostEqual(speeds.max(), 0.132, 1)
         self.assertAlmostEqual(distances.max(), 2859.5, 1)
 

--- a/tests/models/test_stranding.py
+++ b/tests/models/test_stranding.py
@@ -57,10 +57,10 @@ class TestStranding(unittest.TestCase):
 
         # Check calculated trajectory lengths and speeds
         total_length, distances, speeds = o.get_trajectory_lengths()
-        self.assertAlmostEqual(total_length.max(), 15719.5, 1)
+        self.assertAlmostEqual(total_length.max(), 15722.7, 1)
         self.assertAlmostEqual(total_length.min(), 1225.2, 1)
         self.assertAlmostEqual(speeds.max(), 0.132, 1)
-        self.assertAlmostEqual(distances.max(), 2859.5, 1)
+        self.assertAlmostEqual(distances.max(), 2859.0, 1)
 
     def test_stranding_roms(self):
         o = PelagicEggDrift(loglevel=20)

--- a/tests/readers/test_depth.py
+++ b/tests/readers/test_depth.py
@@ -25,7 +25,7 @@ class TestMyFunction(unittest.TestCase):
         
         expected_output = np.array([-0.98333333, -0.5, -0.01666667])        
         assert z_rho.shape == (self.NZ, self.NY, self.NX)
-        np.allclose(z_rho[:,0,0], expected_output)
+        assert np.allclose(z_rho[:,0,0], expected_output)
 
         # zeta 0s array
         zeta = np.zeros((self.NY, self.NX))
@@ -33,7 +33,7 @@ class TestMyFunction(unittest.TestCase):
         
         expected_output = np.array([-0.98333333, -0.5, -0.01666667])
         assert z_rho.shape == (self.NZ, self.NY, self.NX)
-        np.allclose(z_rho[:,0,0], expected_output)
+        assert np.allclose(z_rho[:,0,0], expected_output)
 
 
     def test_sdepth_zeta_zero_Vtransform2(self):
@@ -46,14 +46,14 @@ class TestMyFunction(unittest.TestCase):
         z_rho = depth.sdepth(self.Htot, zeta, self.hc, self.Cs_r, Vtransform=Vtransform)
         expected_output = np.array([-0.98484848, -0.5, -0.01515152])
         assert z_rho.shape == (self.NZ, self.NY, self.NX)
-        np.allclose(z_rho[:,0,0], expected_output)
+        assert np.allclose(z_rho[:,0,0], expected_output)
 
         # zeta 0s array
         zeta = np.zeros((self.NY, self.NX))
         z_rho = depth.sdepth(self.Htot, zeta, self.hc, self.Cs_r, Vtransform=Vtransform)
         expected_output = np.array([-0.98484848, -0.5, -0.01515152])
         assert z_rho.shape == (self.NZ, self.NY, self.NX)
-        np.allclose(z_rho[:,0,0], expected_output)
+        assert np.allclose(z_rho[:,0,0], expected_output)
 
     def test_sdepth_zeta_nonzero_Vtransform1(self):
         """test nonzero zeta in sdepth, Vtransform 1."""
@@ -65,14 +65,14 @@ class TestMyFunction(unittest.TestCase):
         z_rho = depth.sdepth(self.Htot, zeta, self.hc, self.Cs_r, Vtransform=Vtransform)
         expected_output = np.array([-0.96666667,  0.,  0.96666667])        
         assert z_rho.shape == (self.NZ, self.NY, self.NX)
-        np.allclose(z_rho[:,0,0], expected_output)
+        assert np.allclose(z_rho[:,0,0], expected_output)
 
         # zeta 1s array
         zeta = np.ones((self.NY, self.NX))
         z_rho = depth.sdepth(self.Htot, zeta, self.hc, self.Cs_r, Vtransform=Vtransform)
         expected_output = np.array([-0.96666667,  0.,  0.96666667])
         assert z_rho.shape == (self.NZ, self.NY, self.NX)
-        np.allclose(z_rho[:,0,0], expected_output)
+        assert np.allclose(z_rho[:,0,0], expected_output)
 
 
     def test_sdepth_zeta_nonzero_Vtransform2(self):
@@ -85,14 +85,14 @@ class TestMyFunction(unittest.TestCase):
         z_rho = depth.sdepth(self.Htot, zeta, self.hc, self.Cs_r, Vtransform=Vtransform)
         expected_output = np.array([-0.96969697,  0.,  0.96969697])
         assert z_rho.shape == (self.NZ, self.NY, self.NX)
-        np.allclose(z_rho[:,0,0], expected_output)
+        assert np.allclose(z_rho[:,0,0], expected_output)
 
         # zeta 1s array
         zeta = np.ones((self.NY, self.NX))
         z_rho = depth.sdepth(self.Htot, zeta, self.hc, self.Cs_r, Vtransform=Vtransform)
         expected_output = np.array([-0.96969697,  0.,  0.96969697])
         assert z_rho.shape == (self.NZ, self.NY, self.NX)
-        np.allclose(z_rho[:,0,0], expected_output)
+        assert np.allclose(z_rho[:,0,0], expected_output)
 
 
 

--- a/tests/readers/test_netcdf.py
+++ b/tests/readers/test_netcdf.py
@@ -38,6 +38,10 @@ class TestNetCDF(unittest.TestCase):
             '2Feb2016_Nordic_sigma_3d/Nordic_subset.nc')
         lon = 14.0
         lat = 67.3
+
+        # nordicMF is missing angle
+        nordicMF.Dataset["angle"] = nordicMF_all.Dataset.angle
+
         #nordic3d = reader_ROMS_native.Reader(o.test_data_folder() +
         #    '2Feb2016_Nordic_sigma_3d/Nordic-4km_SLEVELS_avg_00_subset2Feb2016.nc')
         #o.add_reader(nordic3d)  # Slightly different results

--- a/tests/readers/test_roms.py
+++ b/tests/readers/test_roms.py
@@ -1,0 +1,185 @@
+import unittest
+from opendrift.readers import reader_ROMS_native
+import xarray as xr
+import numpy as np
+from datetime import datetime
+import pytest
+
+
+class TestROMSReader(unittest.TestCase):
+    def setUp(self):
+        
+        zeta = np.array([[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], [[0.7, 0.8, 0.9], [1.0, 1.1, 1.2]]])
+        # zeta = np.zeros((2,2,3))
+        
+        u_eastward = np.array([[[[1.0, 1.1, 1.2], [1.3, 1.4, 1.5]], [[1.6, 1.7, 1.8], [1.9, 2.0, 2.1]], [[2.2, 2.3, 2.4], [2.5, 2.6, 2.7]]], [[[2.8, 2.9, 3.0], [3.1, 3.2, 3.3]], [[3.4, 3.5, 3.6], [3.7, 3.8, 3.9]], [[4.0, 4.1, 4.2], [4.3, 4.4, 4.5]]]])
+        
+        u = np.array([[[[0.1, 0.2], [0.3, 0.4]], [[0.5, 0.6], [0.7, 0.8]], [[0.9, 1.0], [1.1, 1.2]]], [[[1.3, 1.4], [1.5, 1.6]], [[1.7, 1.8], [1.9, 2.0]], [[2.1, 2.2], [2.3, 2.4]]]])
+        v = np.linspace(0, 1, 2*3*1*3).reshape(2, 3, 1, 3)
+        Cs_r = np.linspace(-1, 0, 3)
+        mask_rho = np.ones((2, 3))
+        # use odd mask values so I can check when used in tests
+        wetdry_mask_rho = np.ones((2, 2, 3))*2
+        mask_u = np.ones((2, 2))
+        mask_v = np.ones((1, 3))
+        angle = np.zeros((2, 3))
+        
+        self.ds = xr.Dataset(
+            {
+                "lon_rho": (["eta_rho", "xi_rho"], [[-152.0, -151.9, -151.8], [-152.0, -151.9, -151.8]]),
+                "lat_rho": (["eta_rho", "xi_rho"], [[60.5, 60.5, 60.5], [60.4, 60.4, 60.4]]),
+                "lon_u": (["eta_u", "xi_u"], [[-151.95, -151.85], [-151.95, -151.85]]),
+                "lat_u": (["eta_u", "xi_u"], [[60.5, 60.5], [60.4, 60.4]]),
+                "lon_v": (["eta_v", "xi_v"], [[-152.0, -151.9, -151.8]]),
+                "lat_v": (["eta_v", "xi_v"], [[60.45, 60.45, 60.45]]),
+                "mask_rho": (["eta_rho", "xi_rho"], mask_rho),
+                "wetdry_mask_rho": (["ocean_time", "eta_rho", "xi_rho"], wetdry_mask_rho),
+                "angle": (["eta_rho", "xi_rho"], angle),
+                "mask_u": (["eta_u", "xi_u"], mask_u),
+                "mask_v": (["eta_v", "xi_v"], mask_v),
+                "ocean_time": ("ocean_time", [0, 1], {"units": "seconds since 1970-01-01"}),
+                "zeta": (["ocean_time", "eta_rho", "xi_rho"], zeta),
+                "s_rho": (["s_rho"], Cs_r),
+                "Cs_r": (["s_rho"], Cs_r),
+                "hc": 16,
+                "u_eastward": (("ocean_time", "s_rho", "eta_rho", "xi_rho"), u_eastward),
+                "v_northward": (("ocean_time", "s_rho", "eta_rho", "xi_rho"), u_eastward),
+                "u": (("ocean_time", "s_rho", "eta_u", "xi_u"), u),
+                "v": (("ocean_time", "s_rho", "eta_v", "xi_v"), v),
+                }
+        )
+    
+    
+    def test_catch_multiple_variables(self):
+        """Catch if multiple variables are present."""
+        standard_mapping = {"u_eastward": 'x_sea_water_velocity'}
+        reader = reader_ROMS_native.Reader(self.ds, standard_name_mapping=standard_mapping)
+        with pytest.raises(ValueError):
+            reader.get_variables("x_sea_water_velocity", datetime(1970, 1, 1), 0, 0, 0)
+
+    def test_get_variables_u_eastward_wetdry_mask_rho(self):
+        """get a variable from the dataset and verify correct mask was used
+        
+        Since wetdry_mask_rho is available and matches u_eastward dims, it should be used.
+        """
+        standard_mapping = {"u_eastward": 'x_sea_water_velocity',
+                            "v_northward": 'y_sea_water_velocity',
+                            'u': 'blah',
+                            'v': 'blah'}  # redirect mapping of u/v so these don't overlap
+        reader = reader_ROMS_native.Reader(self.ds, standard_name_mapping=standard_mapping)
+        var, key = "u_eastward", "x_sea_water_velocity"
+        output, masks = reader.get_variables(key, datetime(1970, 1, 1), 0, 0, 0, testing=True)
+
+        # check that variable was handled correctly
+        assert key in output
+        assert reader.do_not_rotate == ["x_sea_water_velocity", "y_sea_water_velocity"]
+        assert np.allclose(output[key].data, reader.Dataset[var][0,-1,0,0:2].values)
+        # check that wetdry mask was used (can tell by mask value)
+        assert np.allclose(masks["mask_rho"], reader.Dataset["wetdry_mask_rho"][0,0,0:2].values)
+
+    def test_get_variables_u_eastward_mask_rho(self):
+        """get a variable from the dataset and verify correct mask was used
+        
+        wetdry_mask_rho is not available so mask_rho should be used.
+        """
+        standard_mapping = {"u_eastward": 'x_sea_water_velocity',
+                            "v_northward": 'y_sea_water_velocity',
+                            'u': 'blah',
+                            'v': 'blah'}  # redirect mapping of u/v so these don't overlap
+        reader = reader_ROMS_native.Reader(self.ds, standard_name_mapping=standard_mapping)
+        # drop wetdry_mask_rho to test that mask_rho is used
+        reader.Dataset = reader.Dataset.drop_vars("wetdry_mask_rho")
+        var, key = "u_eastward", "x_sea_water_velocity"
+        output, masks = reader.get_variables(key, datetime(1970, 1, 1), 0, 0, 0, testing=True)
+
+        # check that variable was handled correctly
+        assert key in output
+        assert reader.do_not_rotate == ["x_sea_water_velocity", "y_sea_water_velocity"]
+        assert np.allclose(output[key].data, reader.Dataset[var][0,-1,0,0:2].values)
+        # check that mask was used (can tell by mask value)
+        # only mask_rho should have been used since u_eastward on rho grid
+        assert "mask_u" not in masks
+        assert np.allclose(masks["mask_rho"], reader.Dataset["mask_rho"][0,0:2].values)
+
+
+    def test_get_variables_u_mask_u(self):
+        """get a variable from the dataset and verify correct mask was used
+        
+        wetdry_mask_u is not available so mask_u should be used.
+        """
+        standard_mapping = {'u': 'x_sea_water_velocity'} 
+        reader = reader_ROMS_native.Reader(self.ds, standard_name_mapping=standard_mapping)
+        # drop wetdry_mask_rho to test that mask_rho is used
+        reader.Dataset = reader.Dataset.drop_vars("wetdry_mask_rho")
+        var, key = "u", "x_sea_water_velocity"
+        output, masks = reader.get_variables(key, datetime(1970, 1, 1), 0, 0, 0, testing=True)
+
+        # check that variable was handled correctly
+        assert key in output
+        assert reader.do_not_rotate == []
+        assert np.allclose(output[key].data, reader.Dataset[var][0,-1,0,0:2].values)
+        # check that mask was used (can tell by mask value)
+        # mask_rho should not have been used since u on u-grid
+        assert "mask_rho" not in masks
+
+
+class TestROMSReaderRotation(unittest.TestCase):
+    def setUp(self):
+        
+        self.ds = xr.Dataset(
+            data_vars={
+                "u": (("ocean_time", "Z", "Y", "X"), np.zeros((2, 3, 2, 3))),
+                "v": (("ocean_time", "Z", "Y", "X"), np.zeros((2, 3, 2, 3))),
+                "Uwind": (("ocean_time", "Y", "X"), np.zeros((2, 2, 3))),
+                "Vwind": (("ocean_time", "Y", "X"), np.zeros((2, 2, 3))),
+                "Cs_r": (("Z"), np.linspace(-1, 0, 3)),
+                "hc": 16,
+            },
+            coords={
+                "ocean_time": ("ocean_time", [0, 1], {"units": "seconds since 1970-01-01"}),
+                "s_rho": (("Z"), np.linspace(-1, 0, 3)),
+                "lon_rho": (("Y", "X"), np.array([[1, 2, 3], [1, 2, 3]])),
+                "lat_rho": (("Y", "X"), np.array([[1, 1, 1], [2, 2, 2]])),
+            },
+        )
+
+    
+    def test_rotate(self):
+        """test that correct variables are rotated"""
+        
+        # currents and winds have normal ROMS names and should be rotated
+        reader = reader_ROMS_native.Reader(self.ds)
+        assert reader.do_not_rotate == []
+        
+        # having the "east" or "north" in the standard_name attributes also cause
+        # a variable to not be rotated
+        # this is to test the code though this standard mapping would not lead to 
+        # these standard names actually being used outside of the ROMS reader
+        # in opendrift
+        standard_name_mapping = {"u": 'eastward_sea_water_velocity', "v": 'northward_sea_water_velocity'}
+        reader = reader_ROMS_native.Reader(self.ds, standard_name_mapping=standard_name_mapping)
+        assert reader.do_not_rotate == ['eastward_sea_water_velocity', 'northward_sea_water_velocity']
+        
+        # currents have unusual clearly east/north variable names and should not
+        # be rotated
+        self.ds = self.ds.rename_vars({"u": "u_eastward", "v": "v_northward"})
+        standard_name_mapping = {"u_eastward": 'x_sea_water_velocity', "v_northward": 'y_sea_water_velocity'}
+        reader = reader_ROMS_native.Reader(self.ds, standard_name_mapping=standard_name_mapping)
+        assert reader.do_not_rotate == ['x_sea_water_velocity', 'y_sea_water_velocity']
+        
+        # analogous for winds
+        standard_name_mapping = {"Uwind": 'eastward_wind', "Vwind": 'northward_wind'}
+        reader = reader_ROMS_native.Reader(self.ds, standard_name_mapping=standard_name_mapping)
+        assert reader.do_not_rotate == ['eastward_wind', 'northward_wind']
+
+        self.ds = self.ds.rename_vars({"Uwind": "Uwind_eastward", "Vwind": "Vwind_northward"})
+        standard_name_mapping = {"Uwind_eastward": 'x_wind', "Vwind_northward": 'y_wind'}
+        reader = reader_ROMS_native.Reader(self.ds, standard_name_mapping=standard_name_mapping)
+        assert reader.do_not_rotate == ['x_wind', 'y_wind']
+        
+        
+        
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/readers/test_roms.py
+++ b/tests/readers/test_roms.py
@@ -9,8 +9,7 @@ import pytest
 class TestROMSReader(unittest.TestCase):
     def setUp(self):
         
-        zeta = np.array([[[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], [[0.7, 0.8, 0.9], [1.0, 1.1, 1.2]]])
-        # zeta = np.zeros((2,2,3))
+        h = np.ones((2, 3))*10
         
         u_eastward = np.array([[[[1.0, 1.1, 1.2], [1.3, 1.4, 1.5]], [[1.6, 1.7, 1.8], [1.9, 2.0, 2.1]], [[2.2, 2.3, 2.4], [2.5, 2.6, 2.7]]], [[[2.8, 2.9, 3.0], [3.1, 3.2, 3.3]], [[3.4, 3.5, 3.6], [3.7, 3.8, 3.9]], [[4.0, 4.1, 4.2], [4.3, 4.4, 4.5]]]])
         
@@ -33,12 +32,13 @@ class TestROMSReader(unittest.TestCase):
                 "lon_v": (["eta_v", "xi_v"], [[-152.0, -151.9, -151.8]]),
                 "lat_v": (["eta_v", "xi_v"], [[60.45, 60.45, 60.45]]),
                 "mask_rho": (["eta_rho", "xi_rho"], mask_rho),
+                "h": (["eta_rho", "xi_rho"], h),
                 "wetdry_mask_rho": (["ocean_time", "eta_rho", "xi_rho"], wetdry_mask_rho),
                 "angle": (["eta_rho", "xi_rho"], angle),
                 "mask_u": (["eta_u", "xi_u"], mask_u),
                 "mask_v": (["eta_v", "xi_v"], mask_v),
                 "ocean_time": ("ocean_time", [0, 1], {"units": "seconds since 1970-01-01"}),
-                "zeta": (["ocean_time", "eta_rho", "xi_rho"], zeta),
+                # "zeta": (["ocean_time", "eta_rho", "xi_rho"], zeta),
                 "s_rho": (["s_rho"], Cs_r),
                 "Cs_r": (["s_rho"], Cs_r),
                 "hc": 16,
@@ -121,6 +121,42 @@ class TestROMSReader(unittest.TestCase):
         # check that mask was used (can tell by mask value)
         # mask_rho should not have been used since u on u-grid
         assert "mask_rho" not in masks
+
+
+    def test_get_variables_u_depth_zeta_zero(self):
+        """get a variable from the dataset and verify in depth."""
+        standard_mapping = {'u': 'x_sea_water_velocity'}
+        reader = reader_ROMS_native.Reader(self.ds, standard_name_mapping=standard_mapping)
+        # drop wetdry_mask_rho to test that mask_rho is used
+        reader.Dataset = reader.Dataset.drop_vars("wetdry_mask_rho")
+        var, key = "u", "x_sea_water_velocity"
+        zeta = np.zeros((2,2,3))
+        reader.Dataset["zeta"] = (["ocean_time", "eta_rho", "xi_rho"], zeta)
+
+        output = reader.get_variables(key, datetime(1970, 1, 1), 0, 0, [-5], testing=False)
+
+        assert key in output
+        assert reader.do_not_rotate == []
+        # those expected values at 0.5, 0.6 from the input array
+        assert np.allclose(output[key].data[1,0,:], self.ds[var][0,1,0,:].values)
+
+
+    def test_get_variables_u_depth_zeta_nonzero(self):
+        """get a variable from the dataset and verify in depth."""
+        standard_mapping = {'u': 'x_sea_water_velocity'}
+        reader = reader_ROMS_native.Reader(self.ds, standard_name_mapping=standard_mapping)
+        # drop wetdry_mask_rho to test that mask_rho is used
+        reader.Dataset = reader.Dataset.drop_vars("wetdry_mask_rho")
+        var, key = "u", "x_sea_water_velocity"
+        zeta = np.ones((2,2,3))*2
+        reader.Dataset["zeta"] = (["ocean_time", "eta_rho", "xi_rho"], zeta)
+
+        output = reader.get_variables(key, datetime(1970, 1, 1), 0, 0, [-5], testing=False)
+
+        u_expected = [0.64285714, 0.74285714]
+        assert key in output
+        assert reader.do_not_rotate == []
+        assert np.allclose(output[key].data[1,0,:], u_expected)
 
 
 class TestROMSReaderRotation(unittest.TestCase):


### PR DESCRIPTION
* added sea_surface_height to OceanDrift and models that subclass OceanDrift, also a new parameter
* interact_with_seafloor accounts for zeta in bottom check, as does other bottom check in OceanDrift
* angle and zeta are updated in ROMS reader
* z_rho calculation is shifted so that it is 0 at the surface like z 
* tests are updated, including a ROMS reader specific test file
* changed sea_floor_depth_below_sea_level to -20 from -10 for wet/dry cases that are a little more extreme