### PR TITLE
Possible bug in LCS computation ?

### DIFF
--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -4669,14 +4669,15 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                                 time=t + duration,
                                 z=z)
                 o.run(duration=duration, time_step=-time_step)
-                b_x1, b_y1 = proj(o.history['lon'].T[-1].reshape(X.shape),
-                                  o.history['lat'].T[-1].reshape(X.shape))
+                b_x1, b_y1 = proj(o.history['lon'].T[-1][::-1].reshape(X.shape),
+                                  o.history['lat'].T[-1][::-1].reshape(X.shape))
                 lcs['ALCS'][i, :, :] = ftle(b_x1 - X, b_y1 - Y, delta, T)
 
         lcs['RLCS'] = np.ma.masked_invalid(lcs['RLCS'])
         lcs['ALCS'] = np.ma.masked_invalid(lcs['ALCS'])
         # Flipping ALCS left-right. Not sure why this is needed
-        lcs['ALCS'] = lcs['ALCS'][:, ::-1, ::-1]
+        # >> not needed anymore now that re-ordering is done above
+        # lcs['ALCS'] = lcs['ALCS'][:, ::-1, ::-1]
 
         return lcs
 


### PR DESCRIPTION
Hi @knutfrode , @johannesro 

Opening up a PR for review/discussion on this. 

In the FTLE computation, one needs to calculate the displacement from each initial position (X,Y), that are then fed to `ftle()`. 

It seems that opendrift inverts the order of (lon,lat) when run in backwards mode. So doing this below, would return `b_x1,b_y1` matrices that are not ordered the same way as X and Y. 
```                
b_x1, b_y1 = proj(o.history['lon'].T[-1].reshape(X.shape),o.history['lat'].T[-1].reshape(X.shape))
```
This means that when doing this `b_x1-X` it's not substracting the correct initial positions from the final positions. Flipping the final (lon,lat) arrays seems to yield a consistent matrix ordering, and so correct net displacements fed to `ftle`
 
```                
b_x1, b_y1 = proj(o.history['lon'].T[-1][::-1].reshape(X.shape),o.history['lat'].T[-1][::-1].reshape(X.shape))
```

Doing this suppresses the need to flip the array after the `ftle()` call; there was a note in the code that it was unclear why it was needed. 

Now the confusing part...I ran the example `example_double_gyre_LCS.py` with and without these modifications ..and results were actually quite consistent. That's probably a reason why this was not identified at the time...but I'm a bit surprised that results are that consistent with different displacement inputs...Keen to hear your insights on this.
  


 