### PR TITLE
Model property reguired_profiles_z_range is now replaced with config …

### DIFF
--- a/opendrift/models/chemicaldrift.py
+++ b/opendrift/models/chemicaldrift.py
@@ -112,9 +112,6 @@ class ChemicalDrift(OceanDrift):
         'pH_sediment':{'fallback': 6.9, 'profiles': False}, # supplied by the user, with pH_sediment as standard name #
         }
 
-    # The depth range (in m) which profiles shall cover
-    required_profiles_z_range = [-20, 0]
-
 
     def specie_num2name(self,num):
         return self.name_species[num]
@@ -374,6 +371,7 @@ class ChemicalDrift(OceanDrift):
                 if (hasattr(value,'sigma') or hasattr(value,'z') ):
                     self.DOC_vertical_levels_given = True
 
+        super(ChemicalDrift, self).prepare_run()
 
     def init_species(self):
         # Initialize specie types

--- a/opendrift/models/larvalfish.py
+++ b/opendrift/models/larvalfish.py
@@ -82,7 +82,6 @@ class LarvalFish(OceanDrift):
         'sea_surface_wave_stokes_drift_y_velocity': {'fallback': 0},
     }
 
-    required_profiles_z_range = [0, -50]  # The depth range (in m) which profiles should cover
 
     def __init__(self, *args, **kwargs):
 

--- a/opendrift/models/model_template.py
+++ b/opendrift/models/model_template.py
@@ -102,11 +102,10 @@ class ModelTemplate(OceanDrift):
     # If the attribute 'profiles' is True for a variable (as for
     # ocean_vertical_diffusivity in the example above), a vertical profile
     # of this variable is obtained over the vertical depth interval as 
-    # defined below. These profiles are used for the vertical turbulence scheme:
+    # defined by config setting drift:profiles_depth. These profiles are used for the vertical turbulence scheme:
     # https://opendrift.github.io/_modules/opendrift/models/oceandrift.html#OceanDrift.vertical_mixing
     # Profiles are typically required for ocean_vertical_diffusivity, and sometimes for 
     # salinity and temperature in order to calculate the stratification.
-    required_profiles_z_range = [-50, 0]
     
     def __init__(self, *args, **kwargs):
 
@@ -236,6 +235,7 @@ class ModelTemplate(OceanDrift):
 
     def prepare_run(self):
         """Code to be run before a simulation loop (``update()``)"""
+        # This method must also call the corresponding method of parent class
 
     def bottom_interaction(self, seafloor_depth):
         """Sub method of vertical_mixing, determines settling"""

--- a/opendrift/models/openberg_old.py
+++ b/opendrift/models/openberg_old.py
@@ -105,8 +105,6 @@ class OpenBergOld(OpenDriftSimulation):
         'land_binary_mask': {'fallback': None},
         }
 
-    required_profiles_z_range = [-120, 0] # [min_depth, max_depth]
-
     # Default colors for plotting
     status_colors = {'initial': 'green', 'active': 'blue',
                      'missing_data': 'gray', 'stranded': 'red'}

--- a/opendrift/models/openhns.py
+++ b/opendrift/models/openhns.py
@@ -178,8 +178,6 @@ class OpenHNS(OceanDrift):
         },
     }
 
-    # The depth range (in m) which profiles shall cover
-    required_profiles_z_range = [-20, 0]
 
     max_speed = 1.3  # m/s
 

--- a/opendrift/models/openoil/openoil.py
+++ b/opendrift/models/openoil/openoil.py
@@ -292,8 +292,6 @@ class OpenOil(OceanDrift):
         },
     }
 
-    # The depth range (in m) which profiles shall cover
-    required_profiles_z_range = [-20, 0]
 
     max_speed = 1.3  # m/s
 
@@ -673,7 +671,6 @@ class OpenOil(OceanDrift):
         self.timer_end('main loop:updating elements:oil weathering')
 
     def prepare_run(self):
-
         if self.oil_weathering_model == 'noaa':
             self.noaa_mass_balance = {}
             # Populate with seeded mass spread on oiltype.mass_fraction
@@ -705,6 +702,8 @@ class OpenOil(OceanDrift):
         except Exception as e:
             logger.warning('Could not load max water content file')
             print(e)
+
+        super(OpenOil, self).prepare_run()
 
     def oil_weathering_noaa(self):
         '''Oil weathering scheme adopted from NOAA PyGNOME model:

--- a/opendrift/models/pelagicegg.py
+++ b/opendrift/models/pelagicegg.py
@@ -77,8 +77,6 @@ class PelagicEggDrift(OceanDrift):
         'upward_sea_water_velocity': {'fallback': 0},
       }
 
-    # The depth range (in m) which profiles shall cover
-    required_profiles_z_range = [-120, 0]
 
     # Default colors for plotting
     status_colors = {'initial': 'green', 'active': 'blue',

--- a/opendrift/models/radionuclides.py
+++ b/opendrift/models/radionuclides.py
@@ -92,9 +92,6 @@ class RadionuclideDrift(OceanDrift):
         'conc3': {'fallback': 1.e-3},
         }
 
-    # The depth range (in m) which profiles shall cover
-    required_profiles_z_range = [-20, 0]
-
 
     def specie_num2name(self,num):
         return self.name_species[num]
@@ -226,7 +223,7 @@ class RadionuclideDrift(OceanDrift):
         logger.info('nspecies: %s' % self.nspecies)
         logger.info('Transfer rates:\n %s' % self.transfer_rates)
 
-
+        super(RadionuclideDrift, self).prepare_run()
 
 
     def init_species(self):

--- a/opendrift/models/sealice.py
+++ b/opendrift/models/sealice.py
@@ -96,7 +96,6 @@ class SeaLice(OceanDrift):
         'sea_water_salinity': {'fallback': 34}
     }
 
-    # required_profiles_z_range = [0, -50]  # The depth range (in m) which profiles should cover
 
     def __init__(self,*args, **kwargs):
 
@@ -183,6 +182,8 @@ class SeaLice(OceanDrift):
         self.new_born()
         self.population()
         self.ref_date = datetime(1,1,1,0,0)
+
+        super(SeaLice, self).prepare_run()
 
     def new_born(self):
         """

--- a/opendrift/readers/basereader/continuous.py
+++ b/opendrift/readers/basereader/continuous.py
@@ -38,7 +38,7 @@ class ContinuousReader(Variables):
         env_profiles = None
         if profiles is not None:
             # Copying data from environment to vertical profiles
-            env_profiles = {'z': profiles_depth}
+            env_profiles = {'z': [0, -profiles_depth]}
             for var in profiles:
                 env_profiles[var] = np.ma.array([env[var], env[var]])
 

--- a/opendrift/readers/basereader/structured.py
+++ b/opendrift/readers/basereader/structured.py
@@ -233,7 +233,7 @@ class StructuredReader(Variables):
             # requested block has the depth range required for profiles
             mx = np.append(reader_x, [reader_x[-1], reader_x[-1]])
             my = np.append(reader_y, [reader_y[-1], reader_y[-1]])
-            mz = np.append(z, [profiles_depth[0], profiles_depth[1]])
+            mz = np.append(z, [0, -profiles_depth])
         else:
             mx = reader_x
             my = reader_y
@@ -322,7 +322,7 @@ class StructuredReader(Variables):
                            'cover element positions within timestep. '
                            'Buffer size (%s) must be increased. See `Variables.set_buffer_size`.' %
                            (self.name, str(self.buffer)))
-            # TODO; could add dynamic incraes of buffer size here
+            # TODO: could add dynamic increase of buffer size here
 
         ############################################################
         # Interpolate before/after blocks onto particles in space
@@ -389,7 +389,7 @@ class StructuredReader(Variables):
                     env_profiles = env_profiles_before
                 else:
                     # Copying data from environment to vertical profiles
-                    env_profiles = {'z': profiles_depth}
+                    env_profiles = {'z': [0, -profiles_depth]}
                     for var in profiles:
                         env_profiles[var] = np.ma.array([env[var], env[var]])
         self.timer_end('interpolation_time')

--- a/opendrift/readers/basereader/unstructured.py
+++ b/opendrift/readers/basereader/unstructured.py
@@ -67,7 +67,7 @@ class UnstructuredReader(Variables):
         env_profiles = None
         if profiles is not None:
             # Copying data from environment to vertical profiles
-            env_profiles = {'z': profiles_depth}
+            env_profiles = {'z': [0, -profiles_depth]}
             for var in profiles:
                 env_profiles[var] = np.ma.array([env[var], env[var]])
 

--- a/opendrift/readers/basereader/variables.py
+++ b/opendrift/readers/basereader/variables.py
@@ -860,7 +860,7 @@ class Variables(ReaderDomain):
 
             profiles: List of variable names that should be returned for the range in `profiles_depth`.
 
-            profiles_depth: A range [z-start, z-end] for which to return values for profile-variables. The exact z-depth are given by the reader and returned as `z` variable in `env_profiles`.
+            profiles_depth: Profiles variables will be retrieved from surface and down to this depth. The exact z-depth are given by the reader and returned as `z` variable in `env_profiles`.
 
             time: datetime or None, time at which data are requested.
                 Can be None (default) if reader/variable has no time

--- a/tests/models/test_environment.py
+++ b/tests/models/test_environment.py
@@ -13,7 +13,7 @@ def test_add_readers(test_data_roms):
             'fallback': 10
         },
     }
-    env = Environment(required_variables, None, c._config)
+    env = Environment(required_variables, c._config)
     env.add_reader(test_data_roms)
     env.finalize()
 

--- a/tests/models/test_readers.py
+++ b/tests/models/test_readers.py
@@ -422,7 +422,6 @@ class TestReaders(unittest.TestCase):
         assert o.environment_profiles['z'].min() == -75
 
         o = OpenOil()
-        o.required_profiles_depth = [-20, 0]
         o.set_config('drift:profiles_depth', 20)
         o.add_reader(r)
         o.set_config('environment:constant', {'land_binary_mask': 0, 'x_wind': 0, 'y_wind': 0})

--- a/tests/models/test_readers.py
+++ b/tests/models/test_readers.py
@@ -387,7 +387,7 @@ class TestReaders(unittest.TestCase):
         # test also profiles depth
         data, profiles = norkyst3d.get_variables_interpolated(
                 variables, profiles=['sea_water_temperature'],
-                profiles_depth = [-100, 0],
+                profiles_depth = 100,
                 time = norkyst3d.start_time,
                 lon=lon, lat=lat, z=0)
         assert profiles['z'].min() == -150
@@ -395,7 +395,7 @@ class TestReaders(unittest.TestCase):
         # NB TODO: must use later time, otherwise cache (with deeper profile) is reused
         data, profiles = norkyst3d.get_variables_interpolated(
                 variables, profiles=['sea_water_temperature'],
-                profiles_depth = [-30, 0],
+                profiles_depth = 30,
                 time = norkyst3d.start_time + timedelta(hours=1),
                 lon=lon, lat=lat, z=0)
         assert profiles['z'].min() == -75
@@ -403,20 +403,32 @@ class TestReaders(unittest.TestCase):
         norkyst3d.verticalbuffer=0
         data, profiles = norkyst3d.get_variables_interpolated(
                 variables, profiles=['sea_water_temperature'],
-                profiles_depth = [-30, 0],
+                profiles_depth = 30,
                 time = norkyst3d.start_time + timedelta(hours=2),
                 lon=lon, lat=lat, z=0)
         assert profiles['z'].min() == -50
 
     def test_vertical_profile_from_simulation(self):
-        norkyst3d = reader_netCDF_CF_generic.Reader(o.test_data_folder() +
+        o = OpenOil()
+        r = reader_netCDF_CF_generic.Reader(o.test_data_folder() +
             '14Jan2016_NorKyst_z_3d/NorKyst-800m_ZDEPTHS_his_00_3Dsubset.nc')
-        lon = np.array([4.73])
-        lat = np.array([62.35])
         variables = ['x_sea_water_velocity', 'x_sea_water_velocity',
                      'sea_water_temperature']
-        # TODO TO BE COMPLETED
- 
+        N = 10
+        o.add_reader(r)
+        o.set_config('environment:constant', {'land_binary_mask': 0, 'x_wind': 0, 'y_wind': 0})
+        o.seed_elements(lon=np.linspace(4.5, 4.8, N), lat=np.linspace(63, 63.2, N), time=r.start_time)
+        o.run(steps=1)
+        assert o.environment_profiles['z'].min() == -75
+
+        o = OpenOil()
+        o.required_profiles_depth = [-20, 0]
+        o.set_config('drift:profiles_depth', 20)
+        o.add_reader(r)
+        o.set_config('environment:constant', {'land_binary_mask': 0, 'x_wind': 0, 'y_wind': 0})
+        o.seed_elements(lon=np.linspace(4.5, 4.8, N), lat=np.linspace(63, 63.2, N), time=r.start_time)
+        o.run(steps=1)
+        assert o.environment_profiles['z'].min() == -50
 
     def test_vertical_interpolation(self):
         norkyst3d = reader_netCDF_CF_generic.Reader(o.test_data_folder() +
@@ -430,7 +442,7 @@ class TestReaders(unittest.TestCase):
         # space (horizontally, vertically) and then in time
         data, profiles = norkyst3d.get_variables_interpolated(
                 variables, profiles=['sea_water_temperature'],
-                profiles_depth = [-100, 0],
+                profiles_depth = 100,
                 time = norkyst3d.start_time + timedelta(seconds=900),
                 lon=lon, lat=lat, z=z)
         # Check surface value
@@ -486,7 +498,7 @@ class TestReaders(unittest.TestCase):
             o.env.get_environment(list(o.required_variables),
                               reader_nordic.start_time,
                               testlon, testlat, testz,
-                              o.required_profiles)
+                              o.required_profiles, profiles_depth=120)
         self.assertAlmostEqual(env['sea_water_temperature'][0], 4.251, 2)
         self.assertAlmostEqual(env['sea_water_temperature'][1], -0.148, 3)
         self.assertAlmostEqual(env['sea_water_temperature'][4], 10.0)


### PR DESCRIPTION
…setting drift:profile_depth, and profiles are retrieved from surface to this depth. profiles_depth is now input parameter to get_environment, and not anymore a property of Environment class. prepare_run must now always call prepare_run of parent class, since profile_depth is copied to object in basemodel.prepare_run