### PR TITLE
fix z_rho and remove dcrit

### DIFF
--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -701,11 +701,14 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         if 'sea_floor_depth_below_sea_level' not in self.env.priority_list:
             return
 
-        if not hasattr(self, 'environment') or not hasattr(
-                self.environment, 'sea_surface_height'):
-            logger.warning('Seafloor check not being run because sea_surface_height is missing. '
+        if not hasattr(self, 'environment'):
+            logger.warning('Seafloor check not being run because environment is missing. '
                            'This will happen the first time the function is run but if it happens '
                            'subsequently there is probably a problem.')
+            return
+
+        if not hasattr(self.environment, 'sea_surface_height'):
+            logger.warning('Seafloor check not being run because sea_surface_height is missing. ')
             return
 
         # the shape of these is different than the original arrays
@@ -714,9 +717,8 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         sea_surface_height = self.sea_surface_height()
 
         # Check if any elements are below sea floor
-        # But remember that the water column is the sea floor depth + sea surface height + parameter Dcrit
-        Dcrit = self.get_config('general:seafloor_action_dcrit')
-        ibelow = self.elements.z < -(sea_floor_depth + sea_surface_height + Dcrit)
+        # But remember that the water column is the sea floor depth + sea surface height
+        ibelow = self.elements.z < -(sea_floor_depth + sea_surface_height)
         below = np.where(ibelow)[0]
 
         if len(below) == 0:

--- a/opendrift/models/oceandrift.py
+++ b/opendrift/models/oceandrift.py
@@ -160,10 +160,6 @@ class OceanDrift(OpenDriftSimulation):
                 'enum': ['none', 'lift_to_seafloor', 'deactivate', 'previous'],
                 'description': '"deactivate": elements are deactivated; "lift_to_seafloor": elements are lifted to seafloor level; "previous": elements are moved back to previous position; "none"; seafloor is ignored.',
                 'level': CONFIG_LEVEL_ADVANCED},
-            'general:seafloor_action_dcrit': {'type': 'float', 'default': 0.0,
-                'min': 0.0, 'max': 10000, 'units': 'm',
-                'description': 'This parameter represents the amount of water left in a grid cell to keep it wet in a wet/dry simulation for numerical stability. The condition checked for seafloor_action is z < -(sea_floor_depth + sea_surface_height + `general:seafloor_action_dcrit`. It is 0 by default to assume that a wet/dry case is not being run, however, if it is and the correct value is not known 0.1 is a good default to use.',
-                'level': CONFIG_LEVEL_ADVANCED},
             'drift:truncate_ocean_model_below_m': {'type': 'float', 'default': None,
                 'min': 0, 'max': 10000, 'units': 'm',
                 'description': 'Ocean model data are only read down to at most this depth, and extrapolated below. May be specified to read less data to improve performance.',
@@ -421,9 +417,8 @@ class OceanDrift(OpenDriftSimulation):
                 self.elements.z[in_ocean] + self.elements.terminal_velocity[in_ocean] * self.time_step.total_seconds())
 
         # check for minimum height/maximum depth for each particle accouting also for
-        # the sea surface height and the critical/min wet cell depth
-        Dcrit = self.get_config('general:seafloor_action_dcrit')
-        Zmin = -1.*(self.environment.sea_floor_depth_below_sea_level + self.environment.sea_surface_height + Dcrit)
+        # the sea surface height
+        Zmin = -1.*(self.environment.sea_floor_depth_below_sea_level + self.environment.sea_surface_height)
 
         # Let particles stick to bottom
         bottom = np.where(self.elements.z < Zmin)
@@ -500,9 +495,8 @@ class OceanDrift(OpenDriftSimulation):
         dt_mix = self.get_config('vertical_mixing:timestep')
 
         # minimum height/maximum depth for each particle accouting also for
-        # the sea surface height and the critical/min wet cell depth
-        Dcrit = self.get_config('general:seafloor_action_dcrit')
-        Zmin = -1.*(self.environment.sea_floor_depth_below_sea_level + self.environment.sea_surface_height + Dcrit)
+        # the sea surface height
+        Zmin = -1.*(self.environment.sea_floor_depth_below_sea_level + self.environment.sea_surface_height)
 
         # Eventual model specific preparions
         self.prepare_vertical_mixing()


### PR DESCRIPTION
Fix z_rho in ROMS reader: z_rho in the ROMS reader could be greater than 0 for wet/dry scenarios when in a dry area. When this happens, z_rho is now changed to nan instead.

Removed dcrit: Previously I had added a parameter to opendrift, dcrit, which was added to the sea surface height as a minimum value in wet/dry cells. However, I have now realized I misinterpreted the ROMS docs on this issue and it should not be present. Therefore, I have removed it from opendrift entirely.