### PR TITLE
small change to mask values

### DIFF
--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -2510,6 +2510,9 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         if self.history is not None:
             lons = self.history['lon']
             lats = self.history['lat']
+            # mask values of 9.969209968386869e+36
+            lons = np.ma.array(lons, mask=lons == 9.969209968386869e+36)
+            lats = np.ma.array(lats, mask=lats == 9.969209968386869e+36)
         else:
             if self.steps_output > 0:
                 lons = np.ma.array(np.reshape(self.elements.lon, (1, -1))).T


### PR DESCRIPTION
small change to mask values in `get_lonlats(self)` for values of 9.969209968386869e+36

I am not sure why these values occur but they happen when `coastline_action` is set to "stranding" and `seafloor_action` to "deactivate" and then I can't plot the results. I couldn't find a way to avoid the values in the first place instead.

I'm not sure is this is a universal problem or solution. What do you think @knutfrode?