### PR TITLE
Moving basereader.prepare() to variables.prepare(), as the former was…

### DIFF
--- a/opendrift/models/basemodel/environment.py
+++ b/opendrift/models/basemodel/environment.py
@@ -324,11 +324,6 @@ class Environment(Timeable, Configurable):
                         reader.name = tmp_name
                         break
 
-            # Horizontal buffer of reader must be large enough to cover
-            # the distance possibly covered by elements within a time step
-            if not reader.is_lazy:
-                reader.set_buffer_size(max_speed=self.get_config('drift:max_speed'))
-
             self.readers[reader.name] = reader
             logger.debug('Added reader ' + reader.name)
 

--- a/opendrift/models/oceandrift.py
+++ b/opendrift/models/oceandrift.py
@@ -173,7 +173,7 @@ class OceanDrift(OpenDriftSimulation):
                 'level': CONFIG_LEVEL_ESSENTIAL},
             })
 
-        self._set_config_default('drift:max_speed', 1)
+        self._set_config_default('drift:max_speed', 2)
 
     def update(self):
         """Update positions and properties of elements."""

--- a/opendrift/readers/basereader/__init__.py
+++ b/opendrift/readers/basereader/__init__.py
@@ -183,11 +183,6 @@ class BaseReader(Variables, Combine, Filter):
         else:
             return False
 
-    def prepare(self, extent, start_time, end_time, max_speed):
-        """Prepare reader for given simulation coverage in time and space."""
-        logger.debug('Nothing more to prepare for ' + self.name)
-        pass  # to be overriden by specific readers
-
     def index_of_closest_z(self, requested_z):
         """Return (internal) index of z closest to requested z.
 

--- a/opendrift/readers/basereader/structured.py
+++ b/opendrift/readers/basereader/structured.py
@@ -157,6 +157,9 @@ class StructuredReader(Variables):
             # Set buffer large enough for whole simulation
             logger.debug('Time step is None for %s, setting buffer size large nough for whole simulation' % self.name)
             self.set_buffer_size(max_speed, end_time-start_time)
+        else:
+            self.set_buffer_size(max_speed, self.time_step)
+
         super().prepare(extent, start_time, end_time, max_speed)
 
     def set_convolution_kernel(self, convolve):

--- a/opendrift/readers/basereader/variables.py
+++ b/opendrift/readers/basereader/variables.py
@@ -544,6 +544,12 @@ class Variables(ReaderDomain):
 
         super().__init__()
 
+    def prepare(self, extent, start_time, end_time, max_speed):
+        """Prepare reader for given simulation coverage in time and space."""
+        logger.debug('Nothing more to prepare for ' + self.name)
+        pass  # to be overriden by specific readers
+
+
     def activate_environment_mapping(self, mapping_name):
         if mapping_name not in self.environment_mappings:
             raise ValueError('Available environment mappings: ' + str(self.environment_mappings))

--- a/tests/models/test_readers.py
+++ b/tests/models/test_readers.py
@@ -188,7 +188,7 @@ class TestReaders(unittest.TestCase):
                         wind_drift_factor=.02,
                         number=10, radius=1000)
         o.run(steps=8)
-        self.assertEqual(o.num_elements_deactivated(), 4)
+        self.assertEqual(o.num_elements_deactivated(), 1)
 
     #def test_lazy_readers_and_corrupt_data(self):
     #    o = OceanDrift(loglevel=0)
@@ -662,7 +662,7 @@ class TestReaders(unittest.TestCase):
         o.run(steps=2)
         variables.standard_names['x_sea_water_velocity']['valid_max'] = maxval  # reset
         u = o.get_property('x_sea_water_velocity')[0]
-        self.assertAlmostEqual(u.max(), -.069, 3)  # Some numerical error allowed
+        self.assertAlmostEqual(u.max(), -.0718, 3)  # Some numerical error allowed
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
… overriding structured.prepare() due to multiple inheritance, and thus config *drift:max_speed* was not applied if config setting was made after reader was added. Also increasing *drift:max_speed* of OceanDrift from 1 to 2m/s