### PR TITLE
fixed docker builds by migrating to micromamba

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,26 @@
 # See https://opendrift.github.io for usage
 
-FROM condaforge/mambaforge
+# Use a minimal base image
+FROM mambaorg/micromamba:1.4.2
 
-ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+ENV MAMBA_DOCKERFILE_ACTIVATE=1
 
-RUN mkdir /code
-WORKDIR /code
+RUN mkdir code
+WORKDIR code
 
-# Install opendrift environment into base conda environment
+# Copy environment file
 COPY environment.yml .
-RUN mamba env update -n base -f environment.yml
+
+# Install opendrift environment into base micromamba environment
+RUN micromamba install -n base -f environment.yml
 
 # Cache cartopy maps
 RUN /bin/bash -c "echo -e \"import cartopy\nfor s in ('c', 'l', 'i', 'h', 'f'): cartopy.io.shapereader.gshhs(s)\" | python"
 
 # Install opendrift
-ADD . /code
+ADD . .
 RUN pip install -e .
 
 # Test installation
 RUN /bin/bash -c "echo -e \"import opendrift\" | python"
-


### PR DESCRIPTION
The environment.yml and thus the dependencies are completely fine apparently, but the mamba dependency solver is horrible, and so it fails.
Switching to micromamba has completely fixed the issue, and should make dependency fetching faster and more stable.