### PR TITLE
Allow for variables u_eastward,v_northward in reader_ROMS_native. The…

### DIFF
--- a/opendrift/readers/reader_ROMS_native.py
+++ b/opendrift/readers/reader_ROMS_native.py
@@ -101,8 +101,8 @@ class Reader(BaseReader, StructuredReader):
             'zeta': 'sea_surface_height',
             'u': 'x_sea_water_velocity',
             'v': 'y_sea_water_velocity',
-            #'u_eastward': 'x_sea_water_velocity',  # these are wrognly rotated below
-            #'v_northward': 'y_sea_water_velocity',
+            'u_eastward': 'x_sea_water_velocity',
+            'v_northward': 'y_sea_water_velocity',
             'w': 'upward_sea_water_velocity',
             'temp': 'sea_water_temperature',
             'salt': 'sea_water_salinity',


### PR DESCRIPTION
…se are not rotated, which is correct as ROMS reader always has lon-lat CRS