### PR TITLE
[draft] improved closest ocean points for shape readers

### DIFF
--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -329,22 +329,6 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 'description': 'The precision of the particle position approximation to the coastline.',
                 'level': CONFIG_LEVEL_BASIC
             },
-            'general:land_to_ocean_move_buffer': {
-                'type':
-                'float',
-                'min':
-                0.0,
-                'max':
-                np.inf,
-                'default':
-                0,
-                'units':
-                'shape reader projection units',
-                'level':
-                CONFIG_LEVEL_ADVANCED,
-                'description':
-                'Move land particles this many projection units into ocean.'
-            },            
             'general:time_step_minutes': {
                 'type': 'float',
                 'min': .01,
@@ -935,7 +919,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             lon[is_inside], lat[is_inside], _ = land_reader.get_nearest_outside(
                 lon[is_inside],
                 lat[is_inside],
-                buffer=self.get_config('general:land_to_ocean_move_buffer'),
+                buffer_distance=land_reader.get_nearest_outside_buffer,
             )
 
         else:

--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -919,7 +919,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             lon[is_inside], lat[is_inside], _ = land_reader.get_nearest_outside(
                 lon[is_inside],
                 lat[is_inside],
-                buffer_distance=land_reader.get_nearest_outside_buffer,
+                buffer_distance=land_reader._land_kdtree_buffer_distance,
             )
 
         else:

--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -931,7 +931,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         if isinstance(land_reader, ShapeReader):
             # can do this better
-            is_inside = land_reader.is_inside(lon, lat)
+            is_inside = land_reader.__on_land__(lon, lat)
             lon[is_inside], lat[is_inside], _ = land_reader.get_nearest_outside(
                 lon[is_inside],
                 lat[is_inside],

--- a/opendrift/readers/reader_shape.py
+++ b/opendrift/readers/reader_shape.py
@@ -164,24 +164,6 @@ class Reader(BaseReader, ContinuousReader):
 
         return self.kdtree.data[ind, 0], self.kdtree.data[ind, 1], dist
 
-    def is_inside(self, x, y):
-        """
-        Determine whether a set of points are
-            Args:
-                x (deg[]): longitude (decimal degrees) or projected x coordinate
-                y (deg[]): latitude (decimal degrees) or projected y coordinate
-                ...
-
-            x, y, buffer are given in reader local projection.
-
-            Returns:
-                array of bools of the same shape as x, y
-
-        """
-        land = shp.unary_union(self.polys)
-        elements = gpd.GeoSeries.from_xy(x, y)
-        return elements.intersects(land).values
-    
 
 def unwrap(geom):
     """

--- a/opendrift/readers/reader_shape.py
+++ b/opendrift/readers/reader_shape.py
@@ -25,7 +25,6 @@ import itertools
 import logging
 import numpy as np
 from scipy.spatial import cKDTree
-import geopandas as gpd
 import shapely as shp
 from typing import Iterable
 


### PR DESCRIPTION
Hi, I've had a round with the detection of closest ocean points. For shape readers, this is pretty easy, see this PR. I assume there are some things to fix but wanted to hear your ideas first. I am also unsure about using a global config argument for the buffer, and how to name it.

Also attaching a before/after plot where the current PR keeps particles from "tunneling" through narrow pieces of land. @mateuszmatu might have some more detailed plots of what the current algorithm's helper grid looks like for such cases.
 
Before:
![13225-old](https://github.com/user-attachments/assets/3818352b-3bf9-40a6-842e-b2a656320f14)
After:
![13225-new](https://github.com/user-attachments/assets/ec80e49f-6310-41ed-96b1-292b998c196d)
