### PR TITLE
OpenOil: allow providing json file or dictionary as oil_type argument…

### DIFF
--- a/examples/example_wind_drift_coefficient_from_trajectory.py
+++ b/examples/example_wind_drift_coefficient_from_trajectory.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """
-Retieving wind drift factor from trajectory
-===========================================
+Retrieving wind drift factor from trajectory
+============================================
 """
 
 import trajan as _
@@ -139,4 +139,4 @@ plt.show()
 # one position to the next (i.e. polar histogram above).
 # This is even more clear if increasing the diffusivity (i.e. noise) above from 10 m2/s to 200 m2/s:
 # The histogram method then gives 0.071, which is much to high (true is 0.033), and the histogram is noisy.
-# The skillscore method is still robust, and gives a `wind_drift_factor` of 0.036, only slightly too high.
+# The skillscore method is still robust, and gives a `wind_drift_factor` of 0.034, only slightly too high.

--- a/tests/models/openoil/test_openoil_custom_type.py
+++ b/tests/models/openoil/test_openoil_custom_type.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import json
 from importlib.resources import files
 
@@ -15,6 +16,12 @@ def test_set_oil_type_json():
     assert o.oiltype.name == 'GENERIC FUEL OIL No. 6'
     print(o.oiltype)
 
+    o = OpenOil(loglevel=50)
+    o.set_config('environment:constant', {'x_wind': 0, 'y_wind': 0,
+                                          'x_sea_water_velocity': 0, 'y_sea_water_velocity': 0})
+    o.seed_elements(lon=0, lat=0, time=datetime.now(), oil_type=d)
+    assert o.oiltype.name == 'GENERIC FUEL OIL No. 6'
+
 def test_set_oil_type_file():
     o = OpenOil(loglevel=50)
 
@@ -23,3 +30,8 @@ def test_set_oil_type_file():
     assert o.oiltype.name == 'GENERIC FUEL OIL No. 6'
     print(o.oiltype)
 
+    o = OpenOil(loglevel=50)
+    o.set_config('environment:constant', {'x_wind': 0, 'y_wind': 0,
+                                          'x_sea_water_velocity': 0, 'y_sea_water_velocity': 0})
+    o.seed_elements(lon=0, lat=0, time=datetime.now(), oil_type=oiljson)
+    assert o.oiltype.name == 'GENERIC FUEL OIL No. 6'


### PR DESCRIPTION
… to seed methods. Using keyword oiltype instead of oil_type now raises an error.