### PR TITLE
Handle uninstalled dependencies when reporting their versions

### DIFF
--- a/opendrift/__init__.py
+++ b/opendrift/__init__.py
@@ -82,7 +82,7 @@ def versions():
     def version(package):
         try:
             return importlib.metadata.version(package)
-        except:
+        except ImportError:
             return "N/A"
         
     import multiprocessing


### PR DESCRIPTION
Currently, openruns crash when software is not installed whose version `versions` is trying to report. This seems excessive.