### PR TITLE
add an option to get variables with 2 dimension from shyfem readers

### DIFF
--- a/opendrift/readers/unstructured/shyfem.py
+++ b/opendrift/readers/unstructured/shyfem.py
@@ -200,6 +200,16 @@ class Reader(BaseReader, UnstructuredReader):
                         nodes - nodes.min(),
                         level_ind - level_ind.min(),
                         ]
+            elif len(dvar.shape) == 2:
+                # Reading the smallest block covering the actual data
+                block = dvar[indx_nearest,
+                             slice(nodes.min(),
+                                   nodes.max() + 1), ]
+
+                # Picking the nearest value
+                variables[var] = block[
+                        nodes - nodes.min(),
+                        ]
             elif len(dvar.shape) == 1:
                 # Reading the smallest block covering the actual data
                 block = dvar[slice(nodes.min(),


### PR DESCRIPTION
In the function get_variables in the shyfem.py file an option to consider variables with 2 dimension ("nodes" and "time", but not "levels") from unstructured readers created with shyfem is lacking. I propose this modification, in agreement with @knutfrode, to let opendrift use this type of variables, such as sea_surface_height, otherwise the run of a simulation doesn't work, and on the console an error of "unknown dimensionality" appears.

I didn't add also the line 
level_ind = self.__nearest_level__(z)
after
 elif len(dvar.shape) == 2:
as in the original suggestion because I don't think it is necessary since level_ind is not used for the case of 2 dimension
 
