### PR TITLE
[run-ex] Added two new config settings of OceanDrift and submodels (d…

### DIFF
--- a/opendrift/models/openoil/openoil.py
+++ b/opendrift/models/openoil/openoil.py
@@ -481,7 +481,9 @@ class OpenOil(OceanDrift):
         })
 
         self._set_config_default('drift:vertical_advection', False)
+        self._set_config_default('drift:vertical_advection_at_surface', False)
         self._set_config_default('drift:vertical_mixing', True)
+        self._set_config_default('drift:vertical_mixing_at_surface', False)
         self._set_config_default('drift:current_uncertainty', 0.05)
         self._set_config_default('drift:wind_uncertainty', 0.5)
         self._set_config_default('drift:max_speed', 1.3)

--- a/tests/models/test_run.py
+++ b/tests/models/test_run.py
@@ -350,7 +350,7 @@ class TestRun(unittest.TestCase):
 
         o1.run(steps=20, time_step=300, time_step_output=1800,
                export_buffer_length=10, outfile='verticalmixing.nc')
-        self.assertAlmostEqual(o1.result.z.min().values, -42.77, 1)
+        self.assertAlmostEqual(o1.result.z.min().values, -42.60, 1)
         self.assertAlmostEqual(o1.result.z.max().values, 0.0, 1)
         os.remove('verticalmixing.nc')
 
@@ -368,7 +368,7 @@ class TestRun(unittest.TestCase):
                     'zmin': -42.76, 'zmax': -0.02, 'zmean': -14.38},
                 {'vt': .005, 'K': .01, 'K_below': .01, 'T': 60, # Mixing and rising
                     #'zmin': -8.1, 'zmax': -0.01, 'zmean': -2.1},
-                    'zmin': -7.86, 'zmax': -0.01, 'zmean': -2.1},
+                    'zmin': -7.85, 'zmax': -0.01, 'zmean': -2.1},
                 {'vt': -0.005, 'K': .01, 'K_below': .01, 'T': 60, # Mixing and sinking
                     #'zmin': -75.8, 'zmax': -20.7, 'zmean': -48.1},
                     'zmin': -78.76, 'zmax': -19.74, 'zmean': -48.0},

--- a/tests/models/test_run_3d.py
+++ b/tests/models/test_run_3d.py
@@ -28,12 +28,6 @@ from opendrift.readers import reader_ROMS_native
 from opendrift.models.pelagicegg import PelagicEggDrift
 from opendrift.models.oceandrift import OceanDrift
 
-#try:
-#    netCDF4.Dataset('https://thredds.met.no/thredds/dodsC/sea/norkyst800m/1h/aggregate_be')
-#    thredds_support = True
-#except:
-#    thredds_support = False
-
 
 class TestRun(unittest.TestCase):
 
@@ -57,28 +51,9 @@ class TestRun(unittest.TestCase):
         self.assertEqual(o.num_elements_active(), 100)
         self.assertEqual(o.num_elements_deactivated(), 0)
         self.assertAlmostEqual(o.elements.lat[0], 71.16, 1)
-        #self.assertAlmostEqual(o.elements.z.min(), -41.92, 1)  # With past ROMS-masking
-        self.assertAlmostEqual(o.elements.z.min(), -46.75, 1)
+        self.assertAlmostEqual(o.elements.z.min(), -46.65, 1)
         self.assertAlmostEqual(o.elements.z.max(), -0.28, 1)
-        #self.assertAlmostEqual(o.elements.lon.max(), 14.949, 2)
         self.assertAlmostEqual(o.elements.lon.max(), 14.915, 2)
-
-    #@unittest.skipIf(thredds_support is False,
-    #                 'NetCDF4 library does not support OPeNDAP')
-    #def atest_reader_boundary_thredds(self):
-    #    o = PelagicEggDrift(loglevel=20)
-
-    #    reader_norkyst = reader_netCDF_CF_generic.Reader('https://thredds.met.no/thredds/dodsC/sea/norkyst800m/1h/aggregate_be')
-    #    reader_nordic = reader_netCDF_CF_generic.Reader('https://thredds.met.no/thredds/dodsC/fou-hi/nordic4km-1h/Nordic-4km_SURF_1h_avg_00.nc')
-    #    o.add_reader([reader_norkyst, reader_nordic])
-    #    o.set_config('environment:fallback:land_binary_mask', 0)
-    #    lon = 0.2; lat = 61.0; # Close to NorKyst boundary
-    #    time = reader_nordic.start_time
-    #    o.seed_elements(lon, lat, radius=5000, number=100, time=time, z=0)
-    #    o.set_config('vertical_mixing:timestep', 5)
-    #    o.run(steps=5, time_step=3600,
-    #          time_step_output=3600)
-
 
     def test_truncate_ocean_model(self):
         o = OceanDrift(loglevel=30)

--- a/tests/models/test_stranding.py
+++ b/tests/models/test_stranding.py
@@ -58,7 +58,7 @@ class TestStranding(unittest.TestCase):
 
         # Check calculated trajectory lengths and speeds
         total_length, distances, speeds = o.get_trajectory_lengths()
-        self.assertAlmostEqual(total_length.max(), 14981.3, 1)
+        self.assertAlmostEqual(total_length.max(), 14978.7, 1)
         self.assertAlmostEqual(total_length.min(), 1225.2, 1)
         self.assertAlmostEqual(speeds.max(), 0.132, 1)
         self.assertAlmostEqual(distances.max(), 2859.0, 1)


### PR DESCRIPTION
…rift:vertical_advection_at_surface and drift:vertical_mixing_at_surface) to control whether vertical advection and mixing shall apply to elements at very surface (z=0). Both are default False for OpenOil, but default True for other modules.