### PR TITLE
[run-ex] Vertical advection and mixing is disabled by default in OceanDrift (e…

### DIFF
--- a/opendrift/models/chemicaldrift.py
+++ b/opendrift/models/chemicaldrift.py
@@ -346,6 +346,9 @@ class ChemicalDrift(OceanDrift):
                 'level': CONFIG_LEVEL_ESSENTIAL, 'description': ''},
             })
 
+        self._set_config_default('drift:vertical_mixing', True)
+        self._set_config_default('drift:vertical_mixing_at_surface', True)
+        self._set_config_default('drift:vertical_advection_at_surface', True)
 
     def prepare_run(self):
 

--- a/opendrift/models/larvalfish.py
+++ b/opendrift/models/larvalfish.py
@@ -98,6 +98,8 @@ class LarvalFish(OceanDrift):
             })
 
         self._set_config_default('drift:vertical_mixing', True)
+        self._set_config_default('drift:vertical_mixing_at_surface', True)
+        self._set_config_default('drift:vertical_advection_at_surface', True)
 
     def update_terminal_velocity(self, Tprofiles=None,
                                  Sprofiles=None, z_index=None):

--- a/opendrift/models/oceandrift.py
+++ b/opendrift/models/oceandrift.py
@@ -125,12 +125,12 @@ class OceanDrift(OpenDriftSimulation):
             'drift:vertical_advection': {'type': 'bool', 'default': True, 'description':
                 'Advect elements with vertical component of ocean current.',
                 'level': CONFIG_LEVEL_BASIC},
-            'drift:vertical_advection_at_surface': {'type': 'bool', 'default': True, 'description':
+            'drift:vertical_advection_at_surface': {'type': 'bool', 'default': False, 'description':
                 'If vertical advection is activated, surface elements (z=0) can only be advected (downwards) if this setting it True.',
                 'level': CONFIG_LEVEL_ADVANCED},
             'drift:vertical_mixing': {'type': 'bool', 'default': False, 'level': CONFIG_LEVEL_BASIC,
                 'description': 'Activate vertical mixing scheme with inner loop'},
-            'drift:vertical_mixing_at_surface': {'type': 'bool', 'default': True, 'description':
+            'drift:vertical_mixing_at_surface': {'type': 'bool', 'default': False, 'description':
                 'If vertical mixing is activated, surface elements (z=0) can only be mixed (downwards) if this setting it True.',
                 'level': CONFIG_LEVEL_ADVANCED},
             'vertical_mixing:timestep': {'type': 'float', 'min': 0.1, 'max': 3600, 'default': 60,

--- a/opendrift/models/pelagicegg.py
+++ b/opendrift/models/pelagicegg.py
@@ -89,10 +89,12 @@ class PelagicEggDrift(OceanDrift):
         super(PelagicEggDrift, self).__init__(*args, **kwargs)
 
         # By default, eggs do not strand towards coastline
-        self.set_config('general:coastline_action', 'previous')
+        self._set_config_default('general:coastline_action', 'previous')
 
-        # Vertical mixing is enabled by default
-        self.set_config('drift:vertical_mixing', True)
+        # Vertical mixing is enabled by default, also at surface. Also vertical advection at surface.
+        self._set_config_default('drift:vertical_mixing', True)
+        self._set_config_default('drift:vertical_mixing_at_surface', True)
+        self._set_config_default('drift:vertical_advection_at_surface', True)
 
     def update_terminal_velocity(self, Tprofiles=None,
                                  Sprofiles=None, z_index=None):

--- a/opendrift/models/radionuclides.py
+++ b/opendrift/models/radionuclides.py
@@ -201,9 +201,9 @@ class RadionuclideDrift(OceanDrift):
                 'level':CONFIG_LEVEL_ESSENTIAL,
                 'description':'Depth intervals for computation of concentration'},
                         })
-
-
-
+        self._set_config_default('drift:vertical_mixing', True)
+        self._set_config_default('drift:vertical_mixing_at_surface', True)
+        self._set_config_default('drift:vertical_advection_at_surface', True)
 
 
     def prepare_run(self):

--- a/tests/models/test_run.py
+++ b/tests/models/test_run.py
@@ -386,6 +386,8 @@ class TestRun(unittest.TestCase):
             diffusivity[z<-15] = case['K_below']
             o = OceanDrift(loglevel=20)
             o.set_config('drift:vertical_mixing', True)
+            o.set_config('drift:vertical_mixing_at_surface', True)
+            o.set_config('drift:vertical_advection_at_surface', True)
             o.set_config('vertical_mixing:diffusivitymodel', 'environment')
             o.set_config('vertical_mixing:timestep', case['T'])
             o.set_config('environment:fallback:land_binary_mask', 0)


### PR DESCRIPTION
….g. to prevent sinking of simulated surface drifters), but enabled in some sub-modules.