### PR TITLE
[run-ex] method __on_land__ of reader_shape and reader_global_landmas…

### DIFF
--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -956,7 +956,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         if isinstance(land_reader, ShapeReader):
             # can do this better
-            land_indices = land_reader.__on_land__(lon, lat)
+            land_indices = land_reader.get_variables('land_binary_mask', x=lon, y=lat)['land_binary_mask']
             land_indices = np.where(land_indices==1)[0]
             lon[land_indices], lat[land_indices], _ = land_reader.get_nearest_outside(
                 lon[land_indices],

--- a/opendrift/models/chemicaldrift.py
+++ b/opendrift/models/chemicaldrift.py
@@ -2206,9 +2206,9 @@ class ChemicalDrift(OceanDrift):
 
         landmask = np.zeros_like(H[0,0,0,:,:])
         if landmask_shapefile is not None:
-            landmask = self.env.readers['shape'].__on_land__(lon_array,lat_array)
+            landmask = self.env.readers['shape'].get_variables('land_binary_mask', x=lon_array,y=lat_array)['land_binary_mask']
         else:
-            landmask = self.env.readers['global_landmask'].__on_land__(lon_array,lat_array)
+            landmask = self.env.readers['global_landmask'].get_variables('land_binary_mask', x=lon_array,y=lat_array)['land_binary_mask']
 
         if landmask.shape !=  lon_array.shape:
             landmask = landmask.reshape(lon_array.shape)

--- a/opendrift/models/radionuclides.py
+++ b/opendrift/models/radionuclides.py
@@ -1171,9 +1171,9 @@ class RadionuclideDrift(OceanDrift):
 
         landmask = np.zeros_like(H[0,0,0,:,:])
         if landmask_shapefile is not None:
-            landmask = self.env.readers['shape'].__on_land__(lon_array,lat_array)
+            landmask = self.env.readers['shape'].get_variables('land_binary_mask', x=lon_array,y=lat_array)['land_binary_mask']
         else:
-            landmask = self.env.readers['global_landmask'].__on_land__(lon_array,lat_array)
+            landmask = self.env.readers['global_landmask'].get_variables('land_binary_mask', lon_array,lat_array)['land_binary_mask']
 
 
         print('landmask.shape: ', landmask.shape)

--- a/opendrift/readers/reader_global_landmask.py
+++ b/opendrift/readers/reader_global_landmask.py
@@ -222,7 +222,7 @@ class Reader(BaseReader, ContinuousReader):
         # setup landmask
         self.mask = get_mask()
 
-    def __on_land__(self, x, y):
+    def _on_land(self, x, y):
         x = self.modulate_longitude(x)
         x = x.astype(np.float64)
         y = y.astype(np.float64)
@@ -250,4 +250,4 @@ class Reader(BaseReader, ContinuousReader):
         """
 
         self.check_arguments(requestedVariables, time, x, y, z)
-        return {'land_binary_mask': self.__on_land__(x, y)}
+        return {'land_binary_mask': self._on_land(x, y)}

--- a/opendrift/readers/reader_shape.py
+++ b/opendrift/readers/reader_shape.py
@@ -103,7 +103,7 @@ class Reader(BaseReader, ContinuousReader):
         self.xmin, self.ymin = self.lonlat2xy(self.xmin, self.ymin)
         self.xmax, self.ymax = self.lonlat2xy(self.xmax, self.ymax)
 
-    def __on_land__(self, x, y):
+    def _on_land(self, x, y):
         if self.invert is False:
             return shapely.contains_xy(self.land, x, y)
         else:  # Inverse if polygons are lakes and not land areas
@@ -127,7 +127,7 @@ class Reader(BaseReader, ContinuousReader):
         """
 
         self.check_arguments(requestedVariables, time, x, y, z)
-        return { 'x' : x, 'y' : y, 'land_binary_mask': self.__on_land__(x,y) }
+        return { 'x' : x, 'y' : y, 'land_binary_mask': self._on_land(x,y) }
 
     def get_nearest_outside(self, x, y, buffer_distance: float):
         """

--- a/tests/readers/test_global_landmask.py
+++ b/tests/readers/test_global_landmask.py
@@ -11,8 +11,8 @@ def test_global_setup(benchmark):
 def test_landmask_global():
     reader_global = reader_global_landmask.Reader()
 
-    assert reader_global.__on_land__(np.array([10]), np.array([60])) == [True]
-    assert reader_global.__on_land__(np.array([5]), np.array([60])) == [False]
+    assert reader_global._on_land(np.array([10]), np.array([60])) == [True]
+    assert reader_global._on_land(np.array([5]), np.array([60])) == [False]
 
 
 def test_global_array(test_data):
@@ -58,8 +58,8 @@ def test_plot(tmpdir):
 
     plt.figure()
     ax = plt.axes(projection=ccrs.PlateCarree())
-    c = reader_global.__on_land__(xx, yy).reshape(shp)
-    # c = reader_basemap.__on_land__(xx,yy).reshape(shp)
+    c = reader_global._on_land(xx, yy).reshape(shp)
+    # c = reader_basemap._on_land(xx,yy).reshape(shp)
     print(c)
     ex = [18.641, 19.369, 69.538, 69.80]
     plt.imshow(c, extent=ex, transform=ccrs.PlateCarree())
@@ -106,9 +106,9 @@ def test_performance_global(benchmark):
     print("points:", len(xx))
 
     # warmup
-    reader_global.__on_land__(xx, yy)
+    reader_global._on_land(xx, yy)
 
-    benchmark(reader_global.__on_land__, xx, yy)
+    benchmark(reader_global._on_land, xx, yy)
 
 def test_dateline():
     mask = reader_global_landmask.Reader()
@@ -118,7 +118,7 @@ def test_dateline():
 
     xx, yy = np.meshgrid(x, y)
     xx, yy = xx.ravel(), yy.ravel()
-    mm = mask.__on_land__(xx, yy)
+    mm = mask._on_land(xx, yy)
 
     # Offset
     x2 = np.linspace(180, 540, 100)
@@ -127,6 +127,6 @@ def test_dateline():
 
     xx, yy = np.meshgrid(x2, y2)
     xx, yy = xx.ravel(), yy.ravel()
-    MM = mask.__on_land__(xx, yy)
+    MM = mask._on_land(xx, yy)
 
     np.testing.assert_array_equal(mm, MM)

--- a/tests/readers/test_reader_shape.py
+++ b/tests/readers/test_reader_shape.py
@@ -27,8 +27,8 @@ def test_on_land():
                                           name='admin_0_countries')
     r = reader_shape.Reader.from_shpfiles(shpfilename)
 
-    assert r.__on_land__(np.array([10]), np.array([60])) == [True]
-    assert r.__on_land__(np.array([5]), np.array([60])) == [False]
+    assert r._on_land(np.array([10]), np.array([60])) == [True]
+    assert r._on_land(np.array([5]), np.array([60])) == [False]
 
 
 @need_ne_shapes


### PR DESCRIPTION
…k is renamed to _on_land() to be used only internally. Externally to these classes, reader.get_variables() is now used instead