### PR TITLE
Fixes for using landmask from bathymetry instead og GSHHG

### DIFF
--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -393,7 +393,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             'general:coastline_approximation_precision': {
                 'type': 'float',
                 'default': 0.001,
-                'min': 0.,
+                'min': 0.0001,
                 'max': 0.005,
                 'units': 'degrees',
                 'description': 'The precision of the particle position approximation to the coastline.',


### PR DESCRIPTION
useful with high resolution models ( e.g. Norkyst 160m in fjords)
ready to merge