### PR TITLE
Added more tests for OpenBerg, revealing a 180 degree error of wave d…

### DIFF
--- a/opendrift/models/openberg.py
+++ b/opendrift/models/openberg.py
@@ -443,7 +443,7 @@ class OpenBerg(OpenDriftSimulation):
         sea_slope_y = self.environment.sea_surface_y_slope
         sea_surface_height= self.environment.sea_surface_height
         wave_height = self.environment.sea_surface_wave_significant_height
-        wave_direction = self.environment.sea_surface_wave_from_direction
+        wave_direction = -self.environment.sea_surface_wave_from_direction
         sea_ice_thickness = self.environment.sea_ice_thickness
         sea_ice_conc = self.environment.sea_ice_area_fraction
         water_depth = self.environment.sea_floor_depth_below_sea_level

--- a/opendrift/models/physics_methods.py
+++ b/opendrift/models/physics_methods.py
@@ -828,7 +828,7 @@ class PhysicsMethods:
         if hasattr(self.environment, 'sea_surface_wave_from_direction') and \
                 self.environment.sea_surface_wave_from_direction.max() == 0:
             wave_direction = np.rad2deg(np.arctan2(self.environment.x_wind, self.environment.y_wind))
-            self.environment.sea_surface_wave_from_direction = wave_direction
+            self.environment.sea_surface_wave_from_direction = -wave_direction
             logger.warning('Setting wave direction equal to wind direction, min: %f, mean: %f, max: %f' %
                 (wave_direction.min(), wave_direction.mean(), wave_direction.max()))
 

--- a/tests/models/test_openberg.py
+++ b/tests/models/test_openberg.py
@@ -30,6 +30,36 @@ from opendrift.readers import reader_oscillating
 
 def test_openberg_constant_forcing():
 
+    # No current and wind, waves from west
+    o = OpenBerg(loglevel=50)
+    o.set_config('environment:constant:x_sea_water_velocity', 0)
+    o.set_config('environment:constant:y_sea_water_velocity', 0)
+    o.set_config('environment:constant:x_wind', 0)
+    o.set_config('environment:constant:y_wind', 0)
+    o.set_config('environment:constant:sea_surface_wave_significant_height', 3)
+    o.set_config('environment:constant:sea_surface_wave_from_direction', 270)
+    o.set_config('drift:horizontal_diffusivity', 0)
+    o.set_config('drift:coriolis', False)
+    o.seed_elements(4, 60, time=datetime.now())
+    o.run(steps=2)
+    np.testing.assert_almost_equal(o.result.lon.isel(time=-1), 4.127, 3)
+    np.testing.assert_almost_equal(o.result.lat.isel(time=-1), 60.0, 3)
+
+    # No current and wind, waves from east
+    o = OpenBerg(loglevel=50)
+    o.set_config('environment:constant:x_sea_water_velocity', 0)
+    o.set_config('environment:constant:y_sea_water_velocity', 0)
+    o.set_config('environment:constant:x_wind', 0)
+    o.set_config('environment:constant:y_wind', 0)
+    o.set_config('environment:constant:sea_surface_wave_significant_height', 3)
+    o.set_config('environment:constant:sea_surface_wave_from_direction', 90)
+    o.set_config('drift:horizontal_diffusivity', 0)
+    o.set_config('drift:coriolis', False)
+    o.seed_elements(4, 60, time=datetime.now())
+    o.run(steps=2)
+    np.testing.assert_almost_equal(o.result.lon.isel(time=-1), 3.873, 3)
+    np.testing.assert_almost_equal(o.result.lat.isel(time=-1), 60.0, 3)
+
     # Northwards current, no wind, no Coriolis
     o = OpenBerg(loglevel=50)
     o.set_config('environment:constant:x_sea_water_velocity', 0)
@@ -70,7 +100,7 @@ def test_openberg_constant_forcing():
     np.testing.assert_almost_equal(o.result.lat.isel(time=-1), 60.058, 3)
 
     # No current, eastwards wind
-    o = OpenBerg(loglevel=0)
+    o = OpenBerg(loglevel=50)
     o.set_config('environment:constant:x_sea_water_velocity', 0)
     o.set_config('environment:constant:y_sea_water_velocity', 0)
     o.set_config('environment:constant:x_wind', 10)
@@ -83,7 +113,7 @@ def test_openberg_constant_forcing():
     np.testing.assert_almost_equal(o.result.lat.isel(time=-1), 60.000, 3)
 
     # No current, weaker eastwards wind
-    o = OpenBerg(loglevel=0)
+    o = OpenBerg(loglevel=50)
     o.set_config('environment:constant:x_sea_water_velocity', 0)
     o.set_config('environment:constant:y_sea_water_velocity', 0)
     o.set_config('environment:constant:x_wind', 5)
@@ -97,7 +127,7 @@ def test_openberg_constant_forcing():
     np.testing.assert_almost_equal(o.result.lat.isel(time=-1), 60.000, 3)
 
     # No current, westwards wind
-    o = OpenBerg(loglevel=0)
+    o = OpenBerg(loglevel=50)
     o.set_config('environment:constant:x_sea_water_velocity', 0)
     o.set_config('environment:constant:y_sea_water_velocity', 0)
     o.set_config('environment:constant:x_wind', -10)
@@ -110,7 +140,7 @@ def test_openberg_constant_forcing():
     np.testing.assert_almost_equal(o.result.lat.isel(time=-1), 60.000, 3)
 
     # No current, northwards wind
-    o = OpenBerg(loglevel=0)
+    o = OpenBerg(loglevel=50)
     o.set_config('environment:constant:x_sea_water_velocity', 0)
     o.set_config('environment:constant:y_sea_water_velocity', 0)
     o.set_config('environment:constant:x_wind', 0)
@@ -123,7 +153,7 @@ def test_openberg_constant_forcing():
     np.testing.assert_almost_equal(o.result.lat.isel(time=-1), 60.054, 3)
 
     # No current, southwards wind
-    o = OpenBerg(loglevel=0)
+    o = OpenBerg(loglevel=50)
     o.set_config('environment:constant:x_sea_water_velocity', 0)
     o.set_config('environment:constant:y_sea_water_velocity', 0)
     o.set_config('environment:constant:x_wind', 0)
@@ -134,9 +164,6 @@ def test_openberg_constant_forcing():
     o.run(steps=2)
     np.testing.assert_almost_equal(o.result.lon.isel(time=-1), 4, 3)
     np.testing.assert_almost_equal(o.result.lat.isel(time=-1), 59.946, 3)
-
-
-
 
 
 def test_openberg_norkyst():


### PR DESCRIPTION
…irection, and a corresponding 180 degree error in wave direction when retrieving from wind. Thus ice berg drift was wrong when providing wave direction explicitly, but these two error compensated for cases when wave direction was taken from wind direction.