### PR TITLE
Use PEP 508 format for Pixi compatibility

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -38,4 +38,4 @@ dependencies:
   - pip
   - git
   - pip:
-    - git+http://github.com/OpenDrift/trajan.git
+    - trajan @ git+http://github.com/OpenDrift/trajan.git


### PR DESCRIPTION
Update the trajan git repo dependency syntax to that recommended by Python Packaging:
https://packaging.python.org/en/latest/specifications/dependency-specifiers/#dependency-specifiers

This issue arose while using Pixi for package management, which has relatively strict requirements for specifying dependencies. 