### PR TITLE
Update services.rst

### DIFF
--- a/docs/source/services.rst
+++ b/docs/source/services.rst
@@ -21,6 +21,8 @@ Services using OpenDrift
    *  - https://github.com/CNR-ISMAR/pmar
       - `CNR ISMAR <https://www.ismar.cnr.it/web-content/en/about-us/>`_
       - A pipeline for modelling and assessing anthropogenic pressures to support marine management decisions
-
+   *  - https://pollutionmap.seascope.io/
+      - `CALYPSO SCIENCE <https://www.calypso.science/>`_
+      - An open webapp to monitor the dispersion of raw sewage discharged in the ocean in Wellington (New Zealand) following Moa Point wastewater plant damage.   
 
 Please take contact on `GitHub <https://github.com/OpenDrift/opendrift/issues>`_  or `Slack <https://join.slack.com/t/opendrift-dev/shared_invite/zt-ozansc5h-AzMOOS9jOs~3CBihRR37Lw>`_ if you would like to have your service or project listed.


### PR DESCRIPTION
Adding https://pollutionmap.seascope.io/ to the list of services running Opendrift operationally.