### PR TITLE
updated url to norkyst v3 in the introduction docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -67,7 +67,7 @@ Running a simulation can be as simple as:
    >>>
    >>> o = OceanDrift()
    >>> o.add_readers_from_list(
-   >>>     ['https://thredds.met.no/thredds/dodsC/sea/norkyst800m/1h/aggregate_be'])
+   >>>     ['https://thredds.met.no/thredds/dodsC/fou-hi/norkystv3_800m_m00_be'])
    >>> o.seed_elements(lon=4.85, lat=60, time=datetime.now(), number=10000, radius=1000)
    >>>
    >>> o.run(duration=timedelta(hours=24))


### PR DESCRIPTION
Updated the intro page code example to use the NorKyst v3 URL, as the old does not work with `datetime.now()`.

**Note**: I used the m00 version. Is the m61 a better choice for the example?