### PR TITLE
None value handling for openoil seed metadata

### DIFF
--- a/opendrift/models/openoil/openoil.py
+++ b/opendrift/models/openoil/openoil.py
@@ -1610,6 +1610,8 @@ class OpenOil(OceanDrift):
                         self.add_metadata('seed_time', val)
                 elif isinstance(val, str):
                     self.add_metadata('seed_' + s, val)
+                elif val is None and s in ('lat', 'lon'):
+                    pass
                 else:
                     self.add_metadata('seed_' + s, np.atleast_1d(val).mean())
         if not 'seed_oiltype' in self.metadata_dict:

--- a/opendrift/models/openoil/openoil.py
+++ b/opendrift/models/openoil/openoil.py
@@ -1611,6 +1611,9 @@ class OpenOil(OceanDrift):
                 elif isinstance(val, str):
                     self.add_metadata('seed_' + s, val)
                 elif val is None:
+                    logger.debug(
+                        f'Skip seed metadata for None value with variable: {s}'
+                    )
                     pass
                 else:
                     self.add_metadata('seed_' + s, np.atleast_1d(val).mean())

--- a/opendrift/models/openoil/openoil.py
+++ b/opendrift/models/openoil/openoil.py
@@ -1610,7 +1610,7 @@ class OpenOil(OceanDrift):
                         self.add_metadata('seed_time', val)
                 elif isinstance(val, str):
                     self.add_metadata('seed_' + s, val)
-                elif val is None and s in ('lat', 'lon'):
+                elif val is None:
                     pass
                 else:
                     self.add_metadata('seed_' + s, np.atleast_1d(val).mean())


### PR DESCRIPTION
In running a simulation with an openoil model that a) defined its `geojson` parameter, but b) not its `lat` / `lon` parameters, found that `store_oil_seed_metadata` would raise an exception when trying to compute the mean when `val` was `None`. Additional tests showed that the `z` value could also be `None` along with `lat` and `lon`.

This adds an additional check for `val is None` and elects to simply not update seed metadata for the `None` parameter. Debug log message reports on condition.

simulation parameters excerpt for failing case:

```python
{
    'drift_model': 'OpenOil',
    'model': 'opendrift',
    'lon': None,
    'lat': None,
    'geojson': {
        'type': 'Feature',
        'geometry': {
            ...
        }
    },
    'start_time': datetime.datetime(2026, 4, 14, 23, 0, tzinfo=TzInfo(0)),
    'start_time_end': None,
    'run_forward': True,
    'time_step': 300.0,
    'time_step_output_integer': 12,
    'steps': None,
    'duration': 'PT24H',
    'end_time': None,
    'ocean_model': 'CIOFSOP',
    'do3D': True,
    'use_static_masks': False,
    'log_level': 'INFO',
    'horizontal_diffusivity': None,
    'stokes_drift': True,
    'z': 0.0,
    'number': 1000,
    'export_variables': None,
    'plots': None,
    'radius': 0.0,
    'radius_type': 'gaussian',
    'max_speed': 20.0,
    'use_auto_landmask': False,
    'coastline_action': 'stranding',
    'current_uncertainty': 0.0,
    'wind_uncertainty': 0.0,
    'seed_seafloor': True,
    'diffusivitymodel': 'windspeed_Large1994',
    'mixed_layer_depth': 20.0,
    'seafloor_action': 'lift_to_seafloor',
    'wind_drift': True,
    'wind_drift_depth': 0.1,
    'vertical_mixing_timestep': 60.0,
    'wind_drift_factor': 0.03,
    ...
}
```

stacktrace excerpt:

```
  File "/opt/conda/lib/python3.11/site-packages/opendrift/models/openoil/openoil.py", line 1766, in seed_cone
    self.store_oil_seed_metadata(**kwargs)
  File "/opt/conda/lib/python3.11/site-packages/opendrift/models/openoil/openoil.py", line 1616, in store_oil_seed_metadata
    self.add_metadata('seed_' + s, np.atleast_1d(val).mean())
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/numpy/_core/_methods.py", line 144, in _mean
    ret = ret / rcount
          ~~~~^~~~~~~~
TypeError: unsupported operand type(s) for /: 'NoneType' and 'int'
```