### PR TITLE
reader_from_url renamed to reader_from_urlpath, now accepting URI syn…

### DIFF
--- a/examples/example_long_cmems.py
+++ b/examples/example_long_cmems.py
@@ -28,7 +28,7 @@ lon = 123; lat = -16.3  # Australia
 
 o = OceanDrift()
 
-o.add_readers_from_list(['cmems_mod_glo_phy_anfc_merged-uv_PT1H-i'])
+o.add_readers_from_list(['reader_copernicusmarine://cmems_mod_glo_phy_anfc_merged-uv_PT1H-i'])
 
 o.seed_elements(lon=lon, lat=lat, number=5000, radius=1000, time=datetime.utcnow())
 o.run(duration=timedelta(days=3))

--- a/examples/example_thredds_resources.py
+++ b/examples/example_thredds_resources.py
@@ -18,7 +18,7 @@ times = {}
 #%%
 # Open each thredds dataset to check contents and spatial coverage
 for t in thredds_resources:
-    if t.startswith('http') and not t.startswith('cmems'):
+    if t.startswith('http'):
         start = datetime.now()
         print('\n#%%\n%s\n' % t)
         r = Reader(t)

--- a/opendrift/models/basemodel/environment.py
+++ b/opendrift/models/basemodel/environment.py
@@ -8,7 +8,7 @@ from opendrift.timer import Timeable
 from opendrift.config import CONFIG_LEVEL_BASIC, CONFIG_LEVEL_ADVANCED
 from opendrift.readers.basereader import BaseReader, standard_names
 from opendrift.readers.reader_lazy import Reader
-from opendrift.readers import reader_from_url, reader_global_landmask
+from opendrift.readers import reader_from_urlpath, reader_global_landmask
 from opendrift.errors import NotCoveredError
 from opendrift.models import physics_methods as pm
 
@@ -239,15 +239,14 @@ class Environment(Timeable, Configurable):
                                  'following required variables: ' +
                                  str(has_no_fallback))
 
-    def add_readers_from_file(self, filename, timeout=10, lazy=True):
+    def add_readers_from_file(self, filename, lazy=True):
         with open(filename, 'r') as f:
             sources = f.readlines()
             sources = [line.strip() for line in sources if line[0] != '#']
-            self.add_readers_from_list(sources, timeout, lazy=lazy)
+            self.add_readers_from_list(sources, lazy=lazy)
 
     def add_readers_from_list(self,
                               urls,
-                              timeout=10,
                               lazy=True,
                               variables=None):
         '''Make readers from a list of URLs or paths to netCDF datasets'''
@@ -261,7 +260,7 @@ class Environment(Timeable, Configurable):
             self.add_reader(readers, variables=variables)
             return
 
-        readers = [reader_from_url(u, timeout) for u in urls]
+        readers = [reader_from_urlpath(u) for u in urls]
         self.add_reader([r for r in readers if r is not None],
                         variables=variables)
 

--- a/opendrift/readers/__init__.py
+++ b/opendrift/readers/__init__.py
@@ -259,12 +259,12 @@ def reader_from_urlpath(urlpath):
 
     if os.path.exists(urlpath) or path != '':  # URL or filename, no reader specified
         # We try different readers, returning first successful
-        reader_modules = applicable_readers(path)
+        reader_modules = applicable_readers(urlpath)
 
         for reader_module in reader_modules:
             try:
                 logger.debug(f'Testing reader {reader_module}')
-                reader = reader_module.Reader(path)
+                reader = reader_module.Reader(urlpath)
                 return reader
             except Exception as e:
                 logger.debug('Could not open %s with %s' % (urlpath, reader_module))

--- a/opendrift/readers/__init__.py
+++ b/opendrift/readers/__init__.py
@@ -20,8 +20,11 @@ The `ContinuousReader` is suited for data that can be defined at any point withi
     See :class:`.basereader.BaseReader` for how readers work internally.
 """
 
+import os
 from datetime import datetime, timedelta
+import pkgutil
 import importlib
+from urllib.parse import urlparse, parse_qsl
 import logging; logger = logging.getLogger(__name__)
 import glob
 import json
@@ -152,6 +155,24 @@ def open_mfdataset_overlap(url_base, time_series=None, start_time=None, end_time
                    compat='override', combine_attrs='override', join='override', coords='minimal', data_vars='minimal')
     return ds
 
+def all_readers():
+    '''Return a list of all readers in subpackage opendrift.readers'''
+    # Import the sub-package
+    subpackage_name = 'opendrift.readers'
+    subpackage = importlib.import_module(subpackage_name)
+
+    # Get the path of the sub-package
+    package_path = subpackage.__path__
+
+    # List all modules in the sub-package
+    modules = []
+    for _, module_name, is_pkg in pkgutil.iter_modules(package_path):
+        if module_name.startswith('reader_'):
+            #full_module_name = f"{subpackage_name}.{module_name}"
+            modules.append(module_name)
+
+    return modules
+
 def applicable_readers(url):
     '''Return a list of readers that are possible candidates for a given URL, filename or product ID'''
 
@@ -168,35 +189,87 @@ def applicable_readers(url):
         except :
             return []
 
-def reader_from_url(url, timeout=10):
-    '''Make readers from URLs or paths to datasets'''
+#def reader_from_url(url, timeout=10):
+#    '''Make readers from URLs or paths to datasets'''
+#
+#    if isinstance(url, list):
+#        return [reader_from_url(u) for u in url]
+#
+#    try:  # Initialise reader from JSON string
+#        j = json.loads(url)
+#        try:
+#            reader_module = importlib.import_module(
+#                    'opendrift.readers.' + j['reader'])
+#            reader = getattr(reader_module, 'Reader')
+#            del j['reader']
+#            reader = reader(**j)
+#            return reader
+#        except Exception as e:
+#            logger.warning('Creating reader from JSON failed:')
+#            logger.warning(e)
+#    except:
+#        pass
+#
+#    reader_modules = applicable_readers(url)
+#
+#    for reader_module in reader_modules:
+#        try:
+#            logger.debug(f'Testing reader {reader_module}')
+#            r = reader_module.Reader(url)
+#            return r
+#        except Exception as e:
+#            logger.debug('Could not open %s with %s' % (url, reader_module))
+#
+#    return None  # No readers worked
 
-    if isinstance(url, list):
-        return [reader_from_url(u) for u in url]
+def reader_from_urlpath(urlpath):
 
-    try:  # Initialise reader from JSON string
-        j = json.loads(url)
+    if isinstance(urlpath, list):
+        return [reader_from_urlpath(u) for u in urlpath]
+
+    available_readers = all_readers()
+    
+    parsed = urlparse(urlpath.strip())
+
+    if len(parsed.path.split('://')) > 1:
+        requested_reader = parsed.path.split('://')[0]
+        path = parsed.path.split('://')[1]
+    else:
+        requested_reader = None
+        path = parsed.path
+
+    query = parse_qsl(parsed.query)
+    if len(query) == 0:
+        options = {}
+    else:
+        options = dict(query)
+
+    if requested_reader is not None:
         try:
-            reader_module = importlib.import_module(
-                    'opendrift.readers.' + j['reader'])
-            reader = getattr(reader_module, 'Reader')
-            del j['reader']
-            reader = reader(**j)
-            return reader
-        except Exception as e:
-            logger.warning('Creating reader from JSON failed:')
-            logger.warning(e)
-    except:
-        pass
+            reader_module = importlib.import_module(f'opendrift.readers.{requested_reader}')
+        except:
+            logger.debug(f'Cannot import reader {requested_reader}')
+            return None
 
-    reader_modules = applicable_readers(url)
+        if path == '':
+            reader = reader_module.Reader(**options)
+        else:
+            reader = reader_module.Reader(path, **options)
+        return reader
 
-    for reader_module in reader_modules:
-        try:
-            logger.debug(f'Testing reader {reader_module}')
-            r = reader_module.Reader(url)
-            return r
-        except Exception as e:
-            logger.debug('Could not open %s with %s' % (url, reader_module))
+    if os.path.exists(urlpath) or path != '':  # URL or filename, no reader specified
+        # We try different readers, returning first successful
+        reader_modules = applicable_readers(path)
 
-    return None  # No readers worked
+        for reader_module in reader_modules:
+            try:
+                logger.debug(f'Testing reader {reader_module}')
+                reader = reader_module.Reader(path)
+                return reader
+            except Exception as e:
+                logger.debug('Could not open %s with %s' % (urlpath, reader_module))
+
+        return None  # No readers worked
+
+
+

--- a/opendrift/readers/basereader/variables.py
+++ b/opendrift/readers/basereader/variables.py
@@ -171,6 +171,7 @@ class ReaderDomain(Timeable):
         """String representation of the current reader."""
         outStr = '===========================\n'
         outStr += 'Reader: ' + self.name + '\n'
+        outStr += 'Reader type: ' + self.__class__.__module__ + '\n'
         outStr += 'Projection: \n  ' + self.proj4 + '\n'
         outStr += 'Coverage: [%s]\n' % self._coverage_unit_()
         shape = self.shape

--- a/opendrift/readers/reader_constant.py
+++ b/opendrift/readers/reader_constant.py
@@ -17,13 +17,13 @@
 from opendrift.readers.basereader import BaseReader, ContinuousReader
 import numpy as np
 
-
 class Reader(BaseReader, ContinuousReader):
     '''A very simple reader that always give the same value for its variables'''
 
-    def __init__(self, parameter_value_map):
+    def __init__(self, *args, **kwargs):
         """init with a map {'variable_name': value, ...}
         
+        or as variable_name1=value1, variable_name2=value2, ...
         value can also be an array, and in this case the map/dictionary
         must also include `element_ID` which corresponds to the elements that
         shall receive the actual value:
@@ -33,6 +33,10 @@ class Reader(BaseReader, ContinuousReader):
 
         """
 
+        if len(args) == 1 and isinstance(args[0], dict):
+            parameter_value_map = args[0]
+        elif kwargs:
+            parameter_value_map = kwargs
         for key, var in parameter_value_map.items():
             parameter_value_map[key] = np.atleast_1d(var)
         self._parameter_value_map = parameter_value_map

--- a/opendrift/readers/reader_copernicusmarine.py
+++ b/opendrift/readers/reader_copernicusmarine.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 class Reader(Reader_CF_generic):
     '''A wrapper around reader_netCDF_CF_generic for CMEMS datasets'''
 
-    def __init__(self, dataset_id, username=None, password=None, cache_dir=None):
+    def __init__(self, dataset_id, username=None, password=None):
 
         try:
             import copernicusmarine

--- a/opendrift/readers/reader_lazy.py
+++ b/opendrift/readers/reader_lazy.py
@@ -17,7 +17,7 @@
 import logging; logging.captureWarnings(True);
 logger = logging.getLogger(__name__)
 from opendrift.readers.basereader import BaseReader
-from opendrift.readers import reader_from_url, reader_netCDF_CF_generic
+from opendrift.readers import reader_from_urlpath, reader_netCDF_CF_generic
 
 
 class Reader:
@@ -61,7 +61,7 @@ class Reader:
             logger.debug('Lazy reader seems to be zarr, calling reader_netCDF_CF_generic')
             self.reader = reader_netCDF_CF_generic.Reader(filename=self._dataset, zarr_storage_options=self._kwargs['zarr_credentials'], name=self._lazyname)
         else:
-            self.reader = reader_from_url(self._args[0])
+            self.reader = reader_from_urlpath(self._args[0])
 
         if self.reader is None:
             raise ValueError('Reader could not be initialised')

--- a/opendrift/scripts/data_sources.txt
+++ b/opendrift/scripts/data_sources.txt
@@ -6,9 +6,9 @@ https://thredds.met.no/thredds/dodsC/cmems/mywavewam3km/dataset-wam-arctic-1hr3k
 https://thredds.met.no/thredds/dodsC/ww3_4km_agg
 https://thredds.met.no/thredds/dodsC/cmems/topaz6/dataset-topaz6-arc-15min-3km-be.ncml
 https://thredds.met.no/thredds/dodsC/aromearcticlatest/latest/arome_arctic_lagged_6_h_latest_2_5km_latest.nc
-cmems_obs-wind_glo_phy_nrt_l4_0.125deg_PT1H
+reader_copernicusmarine://cmems_obs-wind_glo_phy_nrt_l4_0.125deg_PT1H
 https://thredds.ucar.edu/thredds/dodsC/grib/NCEP/GFS/Global_0p25deg/Best
 https://pae-paha.pacioos.hawaii.edu/thredds/dodsC/ncep_global/NCEP_Global_Atmospheric_Model_best.ncd
-cmems_mod_glo_wav_anfc_0.083deg_PT3H-i
-cmems_mod_glo_phy_anfc_merged-uv_PT1H-i
+reader_copernicusmarine://cmems_mod_glo_wav_anfc_0.083deg_PT3H-i
+reader_copernicusmarine://cmems_mod_glo_phy_anfc_merged-uv_PT1H-i
 https://tds.hycom.org/thredds/dodsC/FMRC_ESPC-D-V02_uv3z/FMRC_ESPC-D-V02_uv3z_best.ncd

--- a/tests/models/test_readers.py
+++ b/tests/models/test_readers.py
@@ -31,7 +31,7 @@ from opendrift.readers import reader_ROMS_native
 from opendrift.readers import reader_global_landmask
 from opendrift.readers import reader_constant
 from opendrift.readers import reader_lazy
-from opendrift.readers import reader_from_url
+from opendrift.readers import reader_from_urlpath
 from opendrift.models.pelagicegg import PelagicEggDrift
 from opendrift.readers import reader_current_from_track
 from opendrift.errors import OutsideSpatialCoverageError, WrongMode
@@ -78,8 +78,8 @@ class TestReaders(unittest.TestCase):
                          [tdf +
             '2Feb2016_Nordic_sigma_3d/AROME_MetCoOp_00_DEF_20160202_subset.nc'])
 
-    def test_reader_from_url(self):
-        readers = reader_from_url(reader_list)
+    def test_reader_from_urlpath(self):
+        readers = reader_from_urlpath(reader_list)
         self.assertIsNone(readers[0])
         self.assertTrue(isinstance(readers[1],
                                    reader_ROMS_native.Reader))

--- a/tests/wps/wps_test.py
+++ b/tests/wps/wps_test.py
@@ -30,7 +30,6 @@ from opendrift.models.openoil import OpenOil
 from opendrift.readers import reader_netCDF_CF_generic
 from opendrift.readers import reader_ROMS_native
 from opendrift.readers import reader_constant
-from opendrift.readers import reader_from_url
 
 
 class TestWPS(unittest.TestCase):


### PR DESCRIPTION
…tax like fsspec: <reader_name>://path?query  E.g. reader_copenicusmarine://cmems_mod_glo_phy_anfc_merged-uv_PT1H-i or reader_constant://?x_wind=3&y_wind=0