### PR TITLE
contrails

### DIFF
--- a/examples/example_contrail_ams_bgo.py
+++ b/examples/example_contrail_ams_bgo.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+"""
+AMS → BGO contrail drift
+========================
+
+Contrail segments are seeded continuously along a flight from Amsterdam
+Schiphol (AMS) to Bergen Airport Flesland (BGO) at cruise altitude
+(10 500 m). The segments then drift eastward on the upper-tropospheric
+jet stream and slowly sublimate. A ✈ icon follows the flight route.
+"""
+
+import numpy as np
+from datetime import datetime, timedelta
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.animation as mplanim
+from opendrift.models.contrail import ContrailDrift
+
+# ── Flight parameters ─────────────────────────────────────────────────────────
+LON_AMS, LAT_AMS = 4.76,  52.31   # Amsterdam Schiphol (AMS)
+LON_BGN, LAT_BGN = 5.22,  60.29   # Bergen Airport Flesland (BGO)
+CRUISE_ALT_M     = 10_500          # cruise altitude [m]
+T_DEPART         = datetime(2024, 6, 15, 10, 0)   # UTC
+FLIGHT_DUR       = timedelta(minutes=90)
+
+# ── Simulation parameters ─────────────────────────────────────────────────────
+SIM_DURATION = timedelta(hours=6)
+TIME_STEP    = 300     # calculation step [s]
+OUTPUT_STEP  = 600     # output / animation step [s]
+N_SEEDS      = 18      # seeding events along route (≈ every 5 minutes)
+N_PER_SEED   = 4       # elements per seeding event
+
+# ── Build model with constant upper-tropospheric forcing ──────────────────────
+c = ContrailDrift(loglevel=30)
+
+# Constant environment – replace with a real NWP reader for a realistic run
+c.set_config('environment:constant:x_wind',             22)     # jet stream [m s-1]
+c.set_config('environment:constant:y_wind',              2)     # slight northward
+c.set_config('environment:constant:air_temperature',   220)     # [K]
+c.set_config('environment:constant:specific_humidity', 8.5e-5)  # near ice-saturation [kg kg-1]
+c.set_config('environment:constant:horizontal_diffusivity', 80) # [m2 s-1]
+c.set_config('contrail:sublimation_timescale',        5400)     # 1.5-h lifetime [s]
+
+# ── Seed contrail segments continuously along the flight path ─────────────────
+fracs      = np.linspace(0, 1, N_SEEDS)
+lons_seed  = LON_AMS + fracs * (LON_BGN - LON_AMS)
+lats_seed  = LAT_AMS + fracs * (LAT_BGN - LAT_AMS)
+times_seed = [T_DEPART + timedelta(seconds=float(f) * FLIGHT_DUR.total_seconds())
+              for f in fracs]
+
+for lon, lat, t in zip(lons_seed, lats_seed, times_seed):
+    c.seed_elements(lon=lon, lat=lat, z=CRUISE_ALT_M,
+                    radius=2_000, number=N_PER_SEED, time=t)
+
+# ── Run the simulation ────────────────────────────────────────────────────────
+c.run(duration=SIM_DURATION, time_step=TIME_STEP, time_step_output=OUTPUT_STEP)
+
+# ── Derive plane position at each output time step ────────────────────────────
+out_times = c.result.time.values          # numpy datetime64 array
+t0_ns     = np.datetime64(T_DEPART)
+tend_ns   = np.datetime64(T_DEPART + FLIGHT_DUR)
+flight_s  = FLIGHT_DUR.total_seconds()
+
+plane_lon = np.full(len(out_times), np.nan)
+plane_lat = np.full(len(out_times), np.nan)
+for k, t in enumerate(out_times):
+    elapsed_s = float((t - t0_ns) / np.timedelta64(1, 's'))
+    if 0 <= elapsed_s <= flight_s:
+        frac = elapsed_s / flight_s
+        plane_lon[k] = LON_AMS + frac * (LON_BGN - LON_AMS)
+        plane_lat[k] = LAT_AMS + frac * (LAT_BGN - LAT_AMS)
+
+# ── Build the map with OpenDrift's helper ─────────────────────────────────────
+corners = [LON_AMS - 0.5, LON_BGN + 8.0,     # extra room eastward for drift
+           LAT_AMS - 0.8, LAT_BGN + 0.8]
+
+fig, ax, _crs_plot, _x, _y, _i0, _i1 = c.set_up_map(
+    corners=corners,
+    ocean_color='aliceblue',
+    land_color='wheat',
+    lscale='i')
+
+crs_ll = c.crs_lonlat   # PlateCarree – used for lon/lat coordinate artists
+
+# Dashed great-circle guide line
+ax.plot([LON_AMS, LON_BGN], [LAT_AMS, LAT_BGN],
+        '--', color='gray', lw=0.8, alpha=0.5, transform=crs_ll, zorder=3)
+
+# Airport markers and labels
+for lon, lat, lbl, xoff in [(LON_AMS, LAT_AMS, 'AMS', 0.1),
+                              (LON_BGN, LAT_BGN, 'BGO', 0.1)]:
+    ax.plot(lon, lat, 'o', ms=5, color='steelblue', transform=crs_ll, zorder=5)
+    ax.text(lon + xoff, lat - 0.2, lbl, transform=crs_ll,
+            fontsize=8, color='steelblue', fontweight='bold', zorder=5)
+
+# ── Animated artists ──────────────────────────────────────────────────────────
+# Active contrail elements (cyan) and sublimated remnants (light gray)
+scat_active = ax.scatter([], [], s=14, c='cyan', alpha=0.8, zorder=6,
+                          transform=crs_ll, label='Active contrail')
+scat_faded  = ax.scatter([], [], s=7,  c='lightgray', alpha=0.3, zorder=5,
+                          transform=crs_ll, label='Sublimated')
+
+# Plane icon – the ✈ character (U+2708) in DejaVu Sans
+plane_icon = ax.text(LON_AMS, LAT_AMS, '\u2708',
+                     transform=crs_ll,
+                     fontsize=22, ha='center', va='center',
+                     rotation=90,            # nose pointing north
+                     color='navy', zorder=8,
+                     visible=False)
+
+title_obj = ax.set_title('')
+ax.legend(loc='lower right', fontsize=8, framealpha=0.85)
+
+# ── Pre-extract trajectory arrays ─────────────────────────────────────────────
+lons_t = c.result.lon.values     # (n_traj, n_time)
+lats_t = c.result.lat.values
+n_times = lons_t.shape[1]
+
+def animate(i):
+    t_str = str(np.datetime_as_string(out_times[i], unit='m')).replace('T', ' ')
+    title_obj.set_text(f'AMS \u2192 BGO  \u2502  {t_str} UTC\n'
+                       f'Contrail drift (constant 22 m s\u207b\u00b9 westerly)')
+
+    # Active particles: not NaN at this time step
+    active = ~np.isnan(lons_t[:, i])
+    faded  = np.zeros(lons_t.shape[0], dtype=bool)
+
+    # Mark as faded: was seeded (not NaN at some earlier step) but now NaN
+    if i > 0:
+        was_active = ~np.isnan(lons_t[:, max(i - 1, 0)])
+        faded = was_active & ~active
+
+    scat_active.set_offsets(
+        np.c_[lons_t[active, i], lats_t[active, i]]
+        if active.any() else np.empty((0, 2)))
+
+    scat_faded.set_offsets(
+        np.c_[lons_t[faded, max(i - 1, 0)], lats_t[faded, max(i - 1, 0)]]
+        if faded.any() else np.empty((0, 2)))
+
+    # Plane icon: visible only while airborne
+    if not np.isnan(plane_lon[i]):
+        plane_icon.set_position((plane_lon[i], plane_lat[i]))
+        plane_icon.set_visible(True)
+    else:
+        plane_icon.set_visible(False)
+
+    return scat_active, scat_faded, plane_icon, title_obj
+
+
+ani = mplanim.FuncAnimation(
+    fig, animate, frames=n_times, interval=150, blit=False)
+
+#%%
+# Save animation – change filename to None to display interactively instead.
+ani.save('example_contrail_ams_bgo.gif', writer='pillow', fps=6,
+         savefig_kwargs={'facecolor': fig.get_facecolor()})
+
+#%%
+# .. image:: /gallery/animations/example_contrail_ams_bgo_0.gif
+
+#%%
+# Static plot of all trajectories
+c.plot(fast=True, ocean_color='aliceblue', land_color='wheat',
+       corners=corners, show_elements=True,
+       title='AMS → BGO contrail drift (6 h)')

--- a/examples/example_contrail_ams_bgo.py
+++ b/examples/example_contrail_ams_bgo.py
@@ -1,45 +1,106 @@
 #!/usr/bin/env python
 """
-AMS → BGO contrail drift
-========================
+AMS → BGO contrail drift with NOAA GFS
+=======================================
 
 Contrail segments are seeded continuously along a flight from Amsterdam
-Schiphol (AMS) to Bergen Airport Flesland (BGO) at cruise altitude
-(10 500 m). The segments then drift eastward on the upper-tropospheric
-jet stream and slowly sublimate. A ✈ icon follows the flight route.
+Schiphol (AMS) to Bergen Airport Flesland (BGO) at **5 km altitude**.
+Wind and temperature are taken from the NOAA GFS forecast (UCAR Thredds
+OPeNDAP). Because GFS stores data on pressure levels, the isobaric level
+nearest to 5 km (~550 hPa) is pre-selected with xarray before handing
+the 2-D field to the OpenDrift reader. A ✈ icon follows the flight route.
 """
 
 import numpy as np
 from datetime import datetime, timedelta
-import matplotlib
+import xarray as xr
 import matplotlib.pyplot as plt
 import matplotlib.animation as mplanim
+from opendrift.readers import reader_netCDF_CF_generic
 from opendrift.models.contrail import ContrailDrift
 
 # ── Flight parameters ─────────────────────────────────────────────────────────
 LON_AMS, LAT_AMS = 4.76,  52.31   # Amsterdam Schiphol (AMS)
 LON_BGN, LAT_BGN = 5.22,  60.29   # Bergen Airport Flesland (BGO)
-CRUISE_ALT_M     = 10_500          # cruise altitude [m]
-T_DEPART         = datetime(2024, 6, 15, 10, 0)   # UTC
-FLIGHT_DUR       = timedelta(minutes=90)
+ALTITUDE_M       = 5_000           # 5 km ≈ 550 hPa
+# Use current UTC time so the GFS Best dataset is always valid
+T_DEPART  = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
+FLIGHT_DUR = timedelta(minutes=90)
+
+# ── Load NOAA GFS at 5 km from UCAR Thredds OPeNDAP ──────────────────────────
+# The GFS "Best" dataset always reflects the most recent available forecast.
+# Wind and temperature are stored on isobaric (pressure) levels in Pa.
+# We pre-select the level closest to 5 km so the reader sees a simple
+# 2-D (time × lat × lon) field without a vertical dimension.
+GFS_URL = ('https://thredds.ucar.edu/thredds/dodsC/'
+           'grib/NCEP/GFS/Global_0p25deg/Best')
+
+# ISA pressure at 5 km: p = 101325 * (1 - 2.2557e-5 * z)^5.2559 ≈ 54 050 Pa
+_isa_pa = 101325.0 * (1.0 - 2.2557e-5 * ALTITUDE_M) ** 5.2559
+
+print(f'Opening GFS dataset: {GFS_URL}')
+ds_gfs = xr.open_dataset(GFS_URL, engine='netcdf4')
+
+
+def _select_level(ds, var_name, target_pa):
+    """Return the DataArray for *var_name* at the isobaric level nearest to
+    *target_pa* (Pascals), handling both Pa and hPa coordinate units."""
+    var = ds[var_name]
+    # Identify the pressure dimension (not time / lat / lon)
+    iso_dim = next(
+        d for d in var.dims
+        if d not in {'time', 'time1', 'lat', 'lon', 'latitude', 'longitude'})
+    iso_vals = ds[iso_dim].values.astype(float)
+    # Detect Pa vs hPa by magnitude
+    target = target_pa if iso_vals.max() > 2000.0 else target_pa / 100.0
+    idx = int(np.argmin(np.abs(iso_vals - target)))
+    print(f'  {var_name}: selecting {iso_dim}={iso_vals[idx]:.0f} '
+          f'({"Pa" if iso_vals.max() > 2000 else "hPa"})')
+    return var.isel({iso_dim: idx})
+
+
+# Assemble a 2-D (time, lat, lon) xarray Dataset at the chosen level.
+# Variable names that carry CF standard_name attributes are recognised and
+# mapped automatically by reader_netCDF_CF_generic:
+#   eastward_wind  → x_wind
+#   northward_wind → y_wind
+#   air_temperature → air_temperature
+#   specific_humidity → specific_humidity
+gfs_vars = {
+    'u-component_of_wind_isobaric': 'u-component_of_wind_isobaric',
+    'v-component_of_wind_isobaric': 'v-component_of_wind_isobaric',
+    'Temperature_isobaric':         'Temperature_isobaric',
+}
+# specific_humidity is not always available; try to include it
+try:
+    gfs_vars['Specific_humidity_isobaric'] = 'Specific_humidity_isobaric'
+    _ = ds_gfs['Specific_humidity_isobaric']
+except KeyError:
+    print('  Specific_humidity_isobaric not found in dataset – using fallback')
+    gfs_vars.pop('Specific_humidity_isobaric', None)
+
+ds_level = xr.Dataset(
+    {name: _select_level(ds_gfs, name, _isa_pa) for name in gfs_vars})
+
+reader_gfs = reader_netCDF_CF_generic.Reader(ds_level)
+print(reader_gfs)
 
 # ── Simulation parameters ─────────────────────────────────────────────────────
-SIM_DURATION = timedelta(hours=6)
+SIM_DURATION = timedelta(hours=4)
 TIME_STEP    = 300     # calculation step [s]
 OUTPUT_STEP  = 600     # output / animation step [s]
 N_SEEDS      = 18      # seeding events along route (≈ every 5 minutes)
 N_PER_SEED   = 4       # elements per seeding event
 
-# ── Build model with constant upper-tropospheric forcing ──────────────────────
-c = ContrailDrift(loglevel=30)
+# ── Build contrail model ───────────────────────────────────────────────────────
+c = ContrailDrift(loglevel=20)
+c.add_reader(reader_gfs)
 
-# Constant environment – replace with a real NWP reader for a realistic run
-c.set_config('environment:constant:x_wind',             22)     # jet stream [m s-1]
-c.set_config('environment:constant:y_wind',              2)     # slight northward
-c.set_config('environment:constant:air_temperature',   220)     # [K]
-c.set_config('environment:constant:specific_humidity', 8.5e-5)  # near ice-saturation [kg kg-1]
-c.set_config('environment:constant:horizontal_diffusivity', 80) # [m2 s-1]
-c.set_config('contrail:sublimation_timescale',        5400)     # 1.5-h lifetime [s]
+# Fallback values for variables not provided by this GFS level
+c.set_config('environment:fallback:specific_humidity',      2e-4)   # kg kg-1
+c.set_config('environment:fallback:horizontal_diffusivity',   50)   # m2 s-1
+# At 5 km the air is typically subsaturated → contrails are short-lived
+c.set_config('contrail:sublimation_timescale', 1800)   # 30-min timescale [s]
 
 # ── Seed contrail segments continuously along the flight path ─────────────────
 fracs      = np.linspace(0, 1, N_SEEDS)
@@ -49,7 +110,7 @@ times_seed = [T_DEPART + timedelta(seconds=float(f) * FLIGHT_DUR.total_seconds()
               for f in fracs]
 
 for lon, lat, t in zip(lons_seed, lats_seed, times_seed):
-    c.seed_elements(lon=lon, lat=lat, z=CRUISE_ALT_M,
+    c.seed_elements(lon=lon, lat=lat, z=ALTITUDE_M,
                     radius=2_000, number=N_PER_SEED, time=t)
 
 # ── Run the simulation ────────────────────────────────────────────────────────
@@ -119,7 +180,7 @@ n_times = lons_t.shape[1]
 def animate(i):
     t_str = str(np.datetime_as_string(out_times[i], unit='m')).replace('T', ' ')
     title_obj.set_text(f'AMS \u2192 BGO  \u2502  {t_str} UTC\n'
-                       f'Contrail drift (constant 22 m s\u207b\u00b9 westerly)')
+                       f'Contrail drift at 5 km (NOAA GFS wind)')
 
     # Active particles: not NaN at this time step
     active = ~np.isnan(lons_t[:, i])
@@ -163,4 +224,4 @@ ani.save('example_contrail_ams_bgo.gif', writer='pillow', fps=6,
 # Static plot of all trajectories
 c.plot(fast=True, ocean_color='aliceblue', land_color='wheat',
        corners=corners, show_elements=True,
-       title='AMS → BGO contrail drift (6 h)')
+       title='AMS → BGO contrail drift at 5 km – NOAA GFS')

--- a/examples/example_contrail_ams_bgo.py
+++ b/examples/example_contrail_ams_bgo.py
@@ -4,11 +4,13 @@ AMS → BGO contrail drift with NOAA GFS
 =======================================
 
 Contrail segments are seeded continuously along a flight from Amsterdam
-Schiphol (AMS) to Bergen Airport Flesland (BGO) at **5 km altitude**.
+Schiphol (AMS) to Bergen Airport Flesland (BGO) at **10 km altitude**.
 Wind and temperature are taken from the NOAA GFS forecast (UCAR Thredds
 OPeNDAP). Because GFS stores data on pressure levels, the isobaric level
-nearest to 5 km (~550 hPa) is pre-selected with xarray before handing
+nearest to 10 km (~250 hPa) is pre-selected with xarray before handing
 the 2-D field to the OpenDrift reader. A ✈ icon follows the flight route.
+Elements where the Schmidt-Appleman Criterion (SAC) is not met are shown
+in orange; sublimated elements are shown in gray.
 """
 
 import numpy as np
@@ -22,20 +24,20 @@ from opendrift.models.contrail import ContrailDrift
 # ── Flight parameters ─────────────────────────────────────────────────────────
 LON_AMS, LAT_AMS = 4.76,  52.31   # Amsterdam Schiphol (AMS)
 LON_BGN, LAT_BGN = 5.22,  60.29   # Bergen Airport Flesland (BGO)
-ALTITUDE_M       = 5_000           # 5 km ≈ 550 hPa
+ALTITUDE_M       = 10_000          # 10 km ≈ 250 hPa
 # Use current UTC time so the GFS Best dataset is always valid
 T_DEPART  = datetime.utcnow().replace(minute=0, second=0, microsecond=0)
 FLIGHT_DUR = timedelta(minutes=90)
 
-# ── Load NOAA GFS at 5 km from UCAR Thredds OPeNDAP ──────────────────────────
+# ── Load NOAA GFS at 10 km from UCAR Thredds OPeNDAP ─────────────────────────
 # The GFS "Best" dataset always reflects the most recent available forecast.
 # Wind and temperature are stored on isobaric (pressure) levels in Pa.
-# We pre-select the level closest to 5 km so the reader sees a simple
+# We pre-select the level closest to 10 km so the reader sees a simple
 # 2-D (time × lat × lon) field without a vertical dimension.
 GFS_URL = ('https://thredds.ucar.edu/thredds/dodsC/'
            'grib/NCEP/GFS/Global_0p25deg/Best')
 
-# ISA pressure at 5 km: p = 101325 * (1 - 2.2557e-5 * z)^5.2559 ≈ 54 050 Pa
+# ISA pressure at 10 km: p = 101325 * (1 - 2.2557e-5 * z)^5.2559 ≈ 26 500 Pa
 _isa_pa = 101325.0 * (1.0 - 2.2557e-5 * ALTITUDE_M) ** 5.2559
 
 print(f'Opening GFS dataset: {GFS_URL}')
@@ -99,8 +101,8 @@ c.add_reader(reader_gfs)
 # Fallback values for variables not provided by this GFS level
 c.set_config('environment:fallback:specific_humidity',      2e-4)   # kg kg-1
 c.set_config('environment:fallback:horizontal_diffusivity',   50)   # m2 s-1
-# At 5 km the air is typically subsaturated → contrails are short-lived
-c.set_config('contrail:sublimation_timescale', 1800)   # 30-min timescale [s]
+# At 10 km the air is cold and often ice-supersaturated → longer-lived contrails
+c.set_config('contrail:sublimation_timescale', 3600)   # 60-min timescale [s]
 
 # ── Seed contrail segments continuously along the flight path ─────────────────
 fracs      = np.linspace(0, 1, N_SEEDS)
@@ -180,7 +182,7 @@ n_times = lons_t.shape[1]
 def animate(i):
     t_str = str(np.datetime_as_string(out_times[i], unit='m')).replace('T', ' ')
     title_obj.set_text(f'AMS \u2192 BGO  \u2502  {t_str} UTC\n'
-                       f'Contrail drift at 5 km (NOAA GFS wind)')
+                       f'Contrail drift at 10 km (NOAA GFS wind)')
 
     # Active particles: not NaN at this time step
     active = ~np.isnan(lons_t[:, i])
@@ -224,4 +226,4 @@ ani.save('example_contrail_ams_bgo.gif', writer='pillow', fps=6,
 # Static plot of all trajectories
 c.plot(fast=True, ocean_color='aliceblue', land_color='wheat',
        corners=corners, show_elements=True,
-       title='AMS → BGO contrail drift at 5 km – NOAA GFS')
+       title='AMS → BGO contrail drift at 10 km – NOAA GFS')

--- a/opendrift/models/contrail.py
+++ b/opendrift/models/contrail.py
@@ -19,6 +19,9 @@
 Each particle represents a small segment of a contrail plume in the upper
 troposphere.  The model resolves:
 
+* **Schmidt-Appleman Criterion (SAC)**: elements are deactivated immediately
+  when ambient temperature exceeds the critical temperature T_SAC, i.e. when
+  conditions do not support contrail formation.
 * **Horizontal advection** by upper-tropospheric winds.
 * **Horizontal diffusion** due to unresolved wind shear and turbulence.
 * **Gravitational sedimentation** of ice crystals.
@@ -61,6 +64,13 @@ _R_V   = 461.5     # Specific gas constant for water vapour [J kg-1 K-1]
 _T0    = 273.16    # Triple-point temperature [K]
 _E0    = 611.73    # Saturation vapour pressure at triple point [Pa]
 _R_D   = 287.05    # Specific gas constant for dry air [J kg-1 K-1]
+
+# SAC mixing-line constants (kerosene / Jet-A fuel)
+_CP_AIR  = 1004.0   # Specific heat of air at constant pressure [J kg-1 K-1]
+_EPS     = 0.622    # Ratio of molar masses Mw / Ma [-]
+_EI_H2O  = 1.25     # Emission index for water vapour [kg_H2O kg_fuel-1]
+_Q_FUEL  = 43.2e6   # Specific combustion heat of kerosene [J kg-1]
+_ETA     = 0.30     # Typical overall propulsion efficiency [-]
 
 
 class ContrailElement(LagrangianArray):
@@ -112,20 +122,28 @@ class ContrailDrift(OpenDriftSimulation):
     attached readers (fallback defaults shown):
 
     * ``x_wind`` / ``y_wind`` — horizontal wind components [m s-1].
-      Readers that provide 3-D wind fields will interpolate to the element
-      altitude automatically.
     * ``air_temperature`` — ambient air temperature [K] (fallback: 220 K).
     * ``specific_humidity`` — water-vapour specific humidity [kg kg-1]
       (fallback: 0, i.e. completely dry → immediate sublimation).
     * ``horizontal_diffusivity`` — horizontal eddy diffusivity [m² s-1]
-      (fallback: 50 m² s-1, representative of upper-tropospheric turbulence).
+      (fallback: 50 m² s-1).
 
     Configuration
     -------------
     ``contrail:sublimation_timescale`` (default 1800 s)
         Characteristic e-folding time for ice sublimation when the ambient
-        air is completely dry (RHi = 0).  The actual loss rate scales
-        linearly with the RHi deficit (1 − RHi).
+        air is completely dry (RHi = 0).
+
+    ``contrail:sac_eta`` (default 0.30)
+        Overall propulsion efficiency η used in the Schmidt-Appleman
+        Criterion (SAC).  Higher efficiency → lower T_SAC → contrails
+        less likely.
+
+    ``contrail:sac_ei_h2o`` (default 1.25 kg kg-1)
+        Emission index for water vapour (kg of H₂O per kg of fuel burned).
+
+    ``contrail:sac_q_fuel`` (default 43.2 × 10⁶ J kg-1)
+        Specific combustion heat of the fuel (kerosene / Jet-A).
 
     Notes
     -----
@@ -134,6 +152,9 @@ class ContrailDrift(OpenDriftSimulation):
     * Coastline interaction is disabled by default (contrails fly over land).
     * ``seed:ocean_only`` is set to ``False`` so elements can be seeded
       above land.
+    * Elements are deactivated with reason ``'no_contrail'`` when the SAC
+      is not satisfied, and with reason ``'sublimated'`` when all ice has
+      sublimated.
     """
 
     ElementType = ContrailElement
@@ -147,8 +168,9 @@ class ContrailDrift(OpenDriftSimulation):
     }
 
     status_colors = {
-        'active':     'cyan',
-        'sublimated': 'lightgray',
+        'active':      'cyan',
+        'sublimated':  'lightgray',
+        'no_contrail': 'orange',
     }
 
     def __init__(self, *args, **kwargs):
@@ -165,6 +187,40 @@ class ContrailDrift(OpenDriftSimulation):
                     'Characteristic sublimation time scale when ambient '
                     'relative humidity over ice is zero.  The ice loss rate '
                     'scales linearly with the RHi deficit.'),
+                'level': CONFIG_LEVEL_ADVANCED,
+            },
+            'contrail:sac_eta': {
+                'type': 'float',
+                'default': _ETA,
+                'min': 0.05,
+                'max': 0.70,
+                'units': '-',
+                'description': (
+                    'Overall propulsion efficiency η for the Schmidt-Appleman '
+                    'Criterion (SAC).  Higher η reduces the mixing-line slope '
+                    'G and lowers T_SAC, making contrail formation less likely.'),
+                'level': CONFIG_LEVEL_ADVANCED,
+            },
+            'contrail:sac_ei_h2o': {
+                'type': 'float',
+                'default': _EI_H2O,
+                'min': 0.5,
+                'max': 2.0,
+                'units': 'kg kg-1',
+                'description': (
+                    'Water-vapour emission index for the Schmidt-Appleman '
+                    'Criterion: kg of H₂O per kg of fuel burned.'),
+                'level': CONFIG_LEVEL_ADVANCED,
+            },
+            'contrail:sac_q_fuel': {
+                'type': 'float',
+                'default': _Q_FUEL,
+                'min': 30.e6,
+                'max': 50.e6,
+                'units': 'J kg-1',
+                'description': (
+                    'Specific combustion heat of the fuel used in the '
+                    'Schmidt-Appleman Criterion.'),
                 'level': CONFIG_LEVEL_ADVANCED,
             },
         })
@@ -198,6 +254,57 @@ class ContrailDrift(OpenDriftSimulation):
         """
         T = np.asarray(T, dtype=float)
         return _E0 * np.exp(_L_SUB / _R_V * (1.0 / _T0 - 1.0 / np.maximum(T, 150.)))
+
+    @staticmethod
+    def _saturation_pressure_over_liquid(T):
+        """Saturation vapour pressure over liquid water [Pa] (Magnus formula).
+
+        Parameters
+        ----------
+        T : array-like
+            Air temperature [K].
+
+        Returns
+        -------
+        numpy.ndarray
+            Saturation vapour pressure over liquid [Pa].
+        """
+        T = np.asarray(T, dtype=float)
+        T_C = T - 273.15
+        return 611.2 * np.exp(17.67 * T_C / (T_C + 243.5))
+
+    @staticmethod
+    def _sac_critical_temperature(G):
+        """Critical temperature T_SAC [K] for the Schmidt-Appleman Criterion.
+
+        Finds T_SAC by solving ``d(e_sat_liq)/dT = G`` via Newton–Raphson
+        iteration on the Magnus formula.  The solution is the temperature at
+        which the exhaust-plume mixing line in the (T, e) diagram is tangent
+        to the liquid-water saturation curve.
+
+        Parameters
+        ----------
+        G : array-like
+            Mixing-line slope [Pa K-1].
+
+        Returns
+        -------
+        numpy.ndarray
+            Critical temperature T_SAC [K].
+        """
+        a, b, c = 17.67, 243.5, 611.2   # Magnus coefficients; e [Pa], T [°C]
+        G = np.asarray(G, dtype=float)
+        T = np.full_like(G, 240.0)       # initial guess [K]
+        for _ in range(12):
+            T_C     = T - 273.15
+            e       = c * np.exp(a * T_C / (T_C + b))
+            de_dT   = e * a * b / (T_C + b) ** 2
+            d2e_dT2 = de_dT * (a * b / (T_C + b) ** 2 - 2.0 / (T_C + b))
+            step    = np.where(np.abs(d2e_dT2) > 1e-15,
+                               (de_dT - G) / d2e_dT2, 0.0)
+            T      -= step
+            T       = np.clip(T, 195.0, 273.15)
+        return T
 
     def _relative_humidity_over_ice(self):
         """Compute relative humidity over ice (RHi) for all active elements.
@@ -233,18 +340,62 @@ class ContrailDrift(OpenDriftSimulation):
 
         Performs the following sub-steps in order:
 
-        1. Horizontal advection with upper-level winds.
-        2. Horizontal diffusion (random walk).
-        3. Gravitational sedimentation (lower altitude by fall speed × dt).
-        4. Sublimation: reduce ice water path and optical depth when
+        1. Schmidt-Appleman Criterion check: deactivate elements where
+           ambient temperature exceeds T_SAC (no contrail can form).
+        2. Horizontal advection with upper-level winds.
+        3. Horizontal diffusion (random walk).
+        4. Gravitational sedimentation (lower altitude by fall speed × dt).
+        5. Sublimation: reduce ice water path and optical depth when
            RHi < 1.
-        5. Deactivate elements whose ice has fully sublimated.
+        6. Deactivate elements whose ice has fully sublimated.
         """
+        self._check_sac()
         self._advect_with_wind()
         self.horizontal_diffusion()
         self._sediment()
         self._sublimate()
         self._deactivate_sublimated()
+
+    def _check_sac(self):
+        """Deactivate elements where the Schmidt-Appleman Criterion is not met.
+
+        The SAC states that contrails form only when ambient temperature is
+        below the critical temperature T_SAC, i.e. when the exhaust-plume
+        mixing line in the (T, e) diagram can reach liquid-water saturation.
+
+        The mixing-line slope G [Pa K-1] depends on aircraft parameters and
+        local pressure::
+
+            G = cp_air * p * EI_H2O / (eps * Q_fuel * (1 - eta))
+
+        T_SAC is found by solving de_sat_liq/dT = G via Newton–Raphson
+        iteration.
+
+        Elements with T > T_SAC are deactivated with reason ``'no_contrail'``.
+        """
+        eta    = self.get_config('contrail:sac_eta')
+        EI_H2O = self.get_config('contrail:sac_ei_h2o')
+        Q      = self.get_config('contrail:sac_q_fuel')
+
+        # ISA pressure at element altitude [Pa]
+        z = np.maximum(self.elements.z, 0.)
+        p = 101325. * np.maximum(1. - 2.2557e-5 * z, 0.) ** 5.2559
+
+        # Mixing-line slope G [Pa K-1]
+        G = _CP_AIR * p * EI_H2O / (_EPS * Q * (1.0 - eta))
+
+        T_SAC = self._sac_critical_temperature(G)
+        T     = self.environment.air_temperature
+
+        no_contrail = T > T_SAC
+        if np.any(no_contrail):
+            logger.debug(
+                '%d elements deactivated: SAC not satisfied '
+                '(T_mean=%.1f K, T_SAC_mean=%.1f K)' % (
+                    int(np.sum(no_contrail)),
+                    float(T[no_contrail].mean()),
+                    float(T_SAC[no_contrail].mean())))
+            self.deactivate_elements(no_contrail, reason='no_contrail')
 
     def _advect_with_wind(self):
         """Advect contrail segments horizontally with upper-tropospheric wind."""

--- a/opendrift/models/contrail.py
+++ b/opendrift/models/contrail.py
@@ -1,0 +1,292 @@
+# This file is part of OpenDrift.
+#
+# OpenDrift is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 2
+#
+# OpenDrift is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenDrift.  If not, see <https://www.gnu.org/licenses/>.
+#
+# Copyright 2024, OpenDrift Developers
+
+"""Lagrangian model for aircraft contrail transport and microphysics.
+
+Each particle represents a small segment of a contrail plume in the upper
+troposphere.  The model resolves:
+
+* **Horizontal advection** by upper-tropospheric winds.
+* **Horizontal diffusion** due to unresolved wind shear and turbulence.
+* **Gravitational sedimentation** of ice crystals.
+* **Sublimation** when ambient air is subsaturated with respect to ice
+  (relative humidity over ice, RHi < 1).  Segments are deactivated once
+  their ice water path has dropped to near zero.
+
+Typical usage::
+
+    import numpy as np
+    from datetime import datetime, timedelta
+    from opendrift.models.contrail import ContrailDrift
+
+    c = ContrailDrift(loglevel=20)
+    c.add_readers_from_list(['nwp_forecast.nc'])
+
+    # Seed a contrail along a trans-Atlantic flight path at 11 km
+    lons = np.linspace(-10, -60, 200)
+    lats = np.linspace(51, 45, 200)
+    c.seed_elements(lon=lons, lat=lats, z=11000,
+                    time=datetime(2024, 6, 1, 12, 0))
+
+    c.run(duration=timedelta(hours=8), time_step=300,
+          time_step_output=1800)
+    c.plot(fast=True)
+"""
+
+import numpy as np
+import logging
+
+logger = logging.getLogger(__name__)
+
+from opendrift.models.basemodel import OpenDriftSimulation
+from opendrift.elements import LagrangianArray
+from opendrift.config import CONFIG_LEVEL_ESSENTIAL, CONFIG_LEVEL_BASIC, CONFIG_LEVEL_ADVANCED
+
+# Thermodynamic constants
+_L_SUB = 2.83e6    # Latent heat of sublimation [J kg-1]
+_R_V   = 461.5     # Specific gas constant for water vapour [J kg-1 K-1]
+_T0    = 273.16    # Triple-point temperature [K]
+_E0    = 611.73    # Saturation vapour pressure at triple point [Pa]
+_R_D   = 287.05    # Specific gas constant for dry air [J kg-1 K-1]
+
+
+class ContrailElement(LagrangianArray):
+    """Lagrangian element representing a contrail ice-crystal segment."""
+
+    variables = LagrangianArray.add_variables([
+        ('ice_water_path', {
+            'dtype': np.float32,
+            'units': 'kg/m2',
+            'description': (
+                'Vertically integrated ice water content per unit area '
+                'of the contrail segment.  Decreases through sublimation.'),
+            'level': CONFIG_LEVEL_ESSENTIAL,
+            'default': 1e-4,
+        }),
+        ('optical_depth', {
+            'dtype': np.float32,
+            'units': '1',
+            'description': (
+                'Visible optical depth of the contrail segment. '
+                'Scales proportionally with ice_water_path.'),
+            'level': CONFIG_LEVEL_BASIC,
+            'default': 0.1,
+        }),
+        ('fall_speed', {
+            'dtype': np.float32,
+            'units': 'm/s',
+            'description': (
+                'Terminal fall speed of ice crystals (positive value = '
+                'downward motion).  Typical range 0.01–0.10 m/s.'),
+            'level': CONFIG_LEVEL_ADVANCED,
+            'default': 0.03,
+        }),
+    ])
+
+
+class ContrailDrift(OpenDriftSimulation):
+    """Lagrangian contrail transport and microphysics model.
+
+    Simulates the drift, spreading and sublimation of aircraft contrail
+    segments in the upper troposphere.  Each Lagrangian element (particle)
+    represents a short contrail segment characterised by its geographic
+    position, altitude, ice water path, optical depth and ice-crystal fall
+    speed.
+
+    Environmental forcing
+    ---------------------
+    The model requires the following CF-convention variable names from
+    attached readers (fallback defaults shown):
+
+    * ``x_wind`` / ``y_wind`` — horizontal wind components [m s-1].
+      Readers that provide 3-D wind fields will interpolate to the element
+      altitude automatically.
+    * ``air_temperature`` — ambient air temperature [K] (fallback: 220 K).
+    * ``specific_humidity`` — water-vapour specific humidity [kg kg-1]
+      (fallback: 0, i.e. completely dry → immediate sublimation).
+    * ``horizontal_diffusivity`` — horizontal eddy diffusivity [m² s-1]
+      (fallback: 50 m² s-1, representative of upper-tropospheric turbulence).
+
+    Configuration
+    -------------
+    ``contrail:sublimation_timescale`` (default 1800 s)
+        Characteristic e-folding time for ice sublimation when the ambient
+        air is completely dry (RHi = 0).  The actual loss rate scales
+        linearly with the RHi deficit (1 − RHi).
+
+    Notes
+    -----
+    * Seed elements with ``z > 0`` (metres above sea level).  Cruise
+      altitudes are typically 8 000–12 000 m.
+    * Coastline interaction is disabled by default (contrails fly over land).
+    * ``seed:ocean_only`` is set to ``False`` so elements can be seeded
+      above land.
+    """
+
+    ElementType = ContrailElement
+
+    required_variables = {
+        'x_wind':                {'fallback': 0},
+        'y_wind':                {'fallback': 0},
+        'air_temperature':       {'fallback': 220},    # K
+        'specific_humidity':     {'fallback': 0},      # kg kg-1
+        'horizontal_diffusivity':{'fallback': 50},     # m2 s-1
+    }
+
+    status_colors = {
+        'active':     'cyan',
+        'sublimated': 'lightgray',
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._add_config({
+            'contrail:sublimation_timescale': {
+                'type': 'float',
+                'default': 1800.,
+                'min': 60.,
+                'max': 86400.,
+                'units': 's',
+                'description': (
+                    'Characteristic sublimation time scale when ambient '
+                    'relative humidity over ice is zero.  The ice loss rate '
+                    'scales linearly with the RHi deficit.'),
+                'level': CONFIG_LEVEL_ADVANCED,
+            },
+        })
+
+        # Contrails are atmospheric; no coastline or ocean-only constraints.
+        self._set_config_default('general:coastline_action', 'none')
+        self._set_config_default('seed:ocean_only', False)
+        self._set_config_default('drift:max_speed', 150)   # allow jet-stream
+
+    # ------------------------------------------------------------------
+    # Thermodynamics helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _saturation_pressure_over_ice(T):
+        """Saturation vapour pressure over ice [Pa] via Clausius–Clapeyron.
+
+        Uses the standard meteorological approximation::
+
+            e_sat = e0 * exp(L_sub / R_v * (1/T0 - 1/T))
+
+        Parameters
+        ----------
+        T : array-like
+            Air temperature [K].
+
+        Returns
+        -------
+        numpy.ndarray
+            Saturation vapour pressure [Pa].
+        """
+        T = np.asarray(T, dtype=float)
+        return _E0 * np.exp(_L_SUB / _R_V * (1.0 / _T0 - 1.0 / np.maximum(T, 150.)))
+
+    def _relative_humidity_over_ice(self):
+        """Compute relative humidity over ice (RHi) for all active elements.
+
+        Ambient pressure is estimated from the International Standard
+        Atmosphere (ISA) using element altitude ``z``.
+
+        Returns
+        -------
+        numpy.ndarray
+            RHi [-], one value per active element.  Values > 1 indicate
+            supersaturation; values < 1 indicate subsaturation.
+        """
+        T = self.environment.air_temperature      # K
+        q = self.environment.specific_humidity    # kg kg-1
+
+        # ISA pressure from altitude [Pa]: valid below ~51 km
+        z = np.maximum(self.elements.z, 0.)
+        p = 101325. * np.maximum(1. - 2.2557e-5 * z, 0.) ** 5.2559
+
+        # Partial pressure of water vapour
+        e = q * p / (0.622 + 0.378 * q)
+
+        e_sat = self._saturation_pressure_over_ice(T)
+        return np.where(e_sat > 0., e / e_sat, 0.)
+
+    # ------------------------------------------------------------------
+    # Update method and sub-steps
+    # ------------------------------------------------------------------
+
+    def update(self):
+        """Advance contrail elements by one time step.
+
+        Performs the following sub-steps in order:
+
+        1. Horizontal advection with upper-level winds.
+        2. Horizontal diffusion (random walk).
+        3. Gravitational sedimentation (lower altitude by fall speed × dt).
+        4. Sublimation: reduce ice water path and optical depth when
+           RHi < 1.
+        5. Deactivate elements whose ice has fully sublimated.
+        """
+        self._advect_with_wind()
+        self.horizontal_diffusion()
+        self._sediment()
+        self._sublimate()
+        self._deactivate_sublimated()
+
+    def _advect_with_wind(self):
+        """Advect contrail segments horizontally with upper-tropospheric wind."""
+        self.update_positions(self.environment.x_wind,
+                              self.environment.y_wind)
+
+    def _sediment(self):
+        """Lower elements by their ice-crystal terminal fall speed."""
+        dt = self.time_step.total_seconds()
+        self.elements.z -= self.elements.fall_speed * dt
+        logger.debug('Sedimentation: elements lowered by %.2f m' %
+                     (self.elements.fall_speed.mean() * dt))
+
+    def _sublimate(self):
+        """Reduce ice water path in subsaturated ambient air.
+
+        The ice water path decays exponentially with a time scale
+        ``tau = sublimation_timescale / max(1 - RHi, epsilon)``.
+        At full saturation (RHi ≥ 1) the ice is stable and no sublimation
+        occurs.
+        """
+        RHi    = self._relative_humidity_over_ice()
+        deficit = np.maximum(1. - RHi, 0.)   # subsaturation fraction [0, 1]
+
+        tau_sub = self.get_config('contrail:sublimation_timescale')
+        dt      = self.time_step.total_seconds()
+
+        # Fractional loss over this time step (linear approximation of exp decay)
+        loss = np.minimum(deficit * dt / tau_sub, 1.)
+
+        self.elements.ice_water_path *= (1. - loss)
+        self.elements.optical_depth  *= (1. - loss)
+
+        n_sub = np.sum(deficit > 0)
+        if n_sub > 0:
+            logger.debug('%d elements sublimating (mean RHi deficit %.3f)' %
+                         (n_sub, deficit[deficit > 0].mean()))
+
+    def _deactivate_sublimated(self):
+        """Deactivate elements whose ice water path has dropped to zero."""
+        fully_sublimated = self.elements.ice_water_path < 1e-8
+        if np.any(fully_sublimated):
+            logger.debug('%d contrail elements fully sublimated' %
+                         np.sum(fully_sublimated))
+            self.deactivate_elements(fully_sublimated, reason='sublimated')

--- a/tests/models/test_contrail.py
+++ b/tests/models/test_contrail.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+#
+# This file is part of OpenDrift.
+#
+# OpenDrift is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 2
+#
+# OpenDrift is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with OpenDrift.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for the ContrailDrift model."""
+
+import pytest
+import numpy as np
+from datetime import datetime, timedelta
+
+from opendrift.models.contrail import ContrailDrift, ContrailElement
+
+
+@pytest.fixture
+def contrail_dry():
+    """ContrailDrift instance in completely dry air (immediate sublimation)."""
+    c = ContrailDrift(loglevel=50)
+    c.set_config('environment:constant:x_wind', 10)
+    c.set_config('environment:constant:y_wind', 0)
+    c.set_config('environment:constant:air_temperature', 220)
+    c.set_config('environment:constant:specific_humidity', 0)   # completely dry
+    c.set_config('environment:constant:horizontal_diffusivity', 0)
+    return c
+
+
+@pytest.fixture
+def contrail_saturated():
+    """ContrailDrift instance in saturated air (no sublimation)."""
+    c = ContrailDrift(loglevel=50)
+    c.set_config('environment:constant:x_wind', 10)
+    c.set_config('environment:constant:y_wind', 0)
+    c.set_config('environment:constant:air_temperature', 220)
+    # Specific humidity that gives RHi >= 1 at 220 K, 11 km altitude
+    # e_sat_ice(220) ≈ 3.5 Pa; p(11 km) ≈ 22 700 Pa
+    # q_sat = 0.622 * e_sat / (p - e_sat) ≈ 0.622 * 3.5 / 22700 ≈ 9.6e-5 kg/kg
+    c.set_config('environment:constant:specific_humidity', 1e-4)
+    c.set_config('environment:constant:horizontal_diffusivity', 0)
+    return c
+
+
+# ------------------------------------------------------------------ #
+# Basic instantiation and configuration                               #
+# ------------------------------------------------------------------ #
+
+def test_import():
+    from opendrift.models.contrail import ContrailDrift
+    assert ContrailDrift is not None
+
+
+def test_contrail_element_variables():
+    expected = {'ice_water_path', 'optical_depth', 'fall_speed'}
+    assert expected.issubset(ContrailElement.variables.keys())
+
+
+def test_coastline_action_default():
+    c = ContrailDrift(loglevel=50)
+    assert c.get_config('general:coastline_action') == 'none'
+
+
+def test_ocean_only_default():
+    c = ContrailDrift(loglevel=50)
+    assert c.get_config('seed:ocean_only') is False
+
+
+# ------------------------------------------------------------------ #
+# Seeding                                                             #
+# ------------------------------------------------------------------ #
+
+def test_seed_above_land(contrail_dry):
+    """Contrails can be seeded above land (seed:ocean_only = False)."""
+    contrail_dry.seed_elements(
+        lon=10.0, lat=48.0, z=11000,
+        time=datetime(2024, 1, 1, 12))
+    assert contrail_dry.num_elements_scheduled() == 1
+
+
+def test_seed_multiple_elements(contrail_dry):
+    lons = np.linspace(-10, 10, 50)
+    lats = np.linspace(51, 53, 50)
+    contrail_dry.seed_elements(
+        lon=lons, lat=lats, z=11000,
+        time=datetime(2024, 1, 1, 12))
+    assert contrail_dry.num_elements_scheduled() == 50
+
+
+def test_seed_custom_properties(contrail_saturated):
+    contrail_saturated.seed_elements(
+        lon=0., lat=50., z=10000,
+        time=datetime(2024, 6, 1),
+        ice_water_path=5e-4,
+        optical_depth=0.5,
+        fall_speed=0.05)
+    contrail_saturated.run(steps=1, time_step=60)
+    np.testing.assert_allclose(
+        contrail_saturated.elements.ice_water_path, 5e-4, rtol=0.05)
+
+
+# ------------------------------------------------------------------ #
+# Advection                                                           #
+# ------------------------------------------------------------------ #
+
+def test_advection_with_wind(contrail_saturated):
+    """Elements should move eastward with a 10 m/s zonal wind."""
+    lon0, lat0 = 0.0, 50.0
+    contrail_saturated.seed_elements(
+        lon=lon0, lat=lat0, z=11000,
+        time=datetime(2024, 1, 1))
+    contrail_saturated.run(duration=timedelta(hours=1), time_step=300)
+
+    lon_final = contrail_saturated.elements.lon[0]
+    assert lon_final > lon0, 'Element should have moved eastward'
+
+
+def test_no_advection_without_wind():
+    """With zero wind, elements should not move horizontally."""
+    c = ContrailDrift(loglevel=50)
+    c.set_config('environment:constant:x_wind', 0)
+    c.set_config('environment:constant:y_wind', 0)
+    c.set_config('environment:constant:air_temperature', 220)
+    c.set_config('environment:constant:specific_humidity', 1e-4)
+    c.set_config('environment:constant:horizontal_diffusivity', 0)
+
+    lon0, lat0 = 5.0, 55.0
+    c.seed_elements(lon=lon0, lat=lat0, z=11000, time=datetime(2024, 1, 1))
+    c.run(duration=timedelta(hours=2), time_step=300)
+
+    np.testing.assert_allclose(c.elements.lon[0], lon0, atol=1e-4)
+    np.testing.assert_allclose(c.elements.lat[0], lat0, atol=1e-4)
+
+
+# ------------------------------------------------------------------ #
+# Sedimentation                                                       #
+# ------------------------------------------------------------------ #
+
+def test_sedimentation_lowers_altitude(contrail_saturated):
+    """Ice crystals should fall (z should decrease over time)."""
+    z0 = 11000.
+    contrail_saturated.seed_elements(
+        lon=0., lat=50., z=z0, time=datetime(2024, 1, 1))
+    contrail_saturated.run(duration=timedelta(hours=2), time_step=300)
+
+    z_final = contrail_saturated.elements.z[0]
+    assert z_final < z0, 'Element altitude should decrease due to sedimentation'
+
+
+def test_sedimentation_rate(contrail_saturated):
+    """Altitude decrease should match fall_speed × elapsed time."""
+    z0 = 11000.
+    fall_speed = 0.03   # m/s (default)
+    duration_s = 3600.  # 1 hour
+
+    contrail_saturated.seed_elements(
+        lon=0., lat=50., z=z0, time=datetime(2024, 1, 1))
+    contrail_saturated.run(duration=timedelta(seconds=duration_s),
+                           time_step=300)
+
+    expected_z = z0 - fall_speed * duration_s
+    np.testing.assert_allclose(
+        contrail_saturated.elements.z[0], expected_z, rtol=1e-3)
+
+
+# ------------------------------------------------------------------ #
+# Sublimation                                                         #
+# ------------------------------------------------------------------ #
+
+def test_sublimation_in_dry_air(contrail_dry):
+    """Ice water path should decrease in completely dry air."""
+    iwp0 = 1e-4
+    contrail_dry.seed_elements(
+        lon=0., lat=50., z=11000,
+        time=datetime(2024, 1, 1),
+        ice_water_path=iwp0)
+    contrail_dry.run(duration=timedelta(minutes=30), time_step=60)
+
+    iwp_final = contrail_dry.elements.ice_water_path
+    # Allow for deactivation (empty array) or reduced IWP
+    if len(iwp_final) > 0:
+        assert np.all(iwp_final < iwp0), 'IWP should decrease in dry air'
+
+
+def test_no_sublimation_in_saturated_air(contrail_saturated):
+    """Ice water path should remain constant in fully saturated air."""
+    iwp0 = 1e-4
+    contrail_saturated.seed_elements(
+        lon=0., lat=50., z=11000,
+        time=datetime(2024, 1, 1),
+        ice_water_path=iwp0)
+    contrail_saturated.run(duration=timedelta(hours=2), time_step=300)
+
+    np.testing.assert_allclose(
+        contrail_saturated.elements.ice_water_path[0], iwp0, rtol=1e-4)
+
+
+def test_elements_deactivated_after_sublimation(contrail_dry):
+    """All elements should be deactivated after sufficient time in dry air."""
+    contrail_dry.set_config('contrail:sublimation_timescale', 300.)
+    contrail_dry.seed_elements(
+        lon=np.linspace(0, 5, 10),
+        lat=np.full(10, 50.),
+        z=11000,
+        time=datetime(2024, 1, 1),
+        ice_water_path=1e-4)
+    contrail_dry.run(duration=timedelta(hours=3), time_step=60)
+
+    assert contrail_dry.num_elements_active() == 0, (
+        'All elements should sublimate in completely dry air')
+    assert contrail_dry.num_elements_total() == 10
+
+
+# ------------------------------------------------------------------ #
+# Thermodynamics helper
+# ------------------------------------------------------------------ #
+
+def test_saturation_pressure_over_ice():
+    """e_sat_ice should be ~611 Pa at 273.16 K (triple point)."""
+    e = ContrailDrift._saturation_pressure_over_ice(np.array([273.16]))
+    np.testing.assert_allclose(e, 611.73, rtol=1e-3)
+
+
+def test_saturation_pressure_increases_with_temperature():
+    T = np.array([200., 220., 240., 260.])
+    e = ContrailDrift._saturation_pressure_over_ice(T)
+    assert np.all(np.diff(e) > 0), 'e_sat should increase with temperature'

--- a/tests/models/test_contrail.py
+++ b/tests/models/test_contrail.py
@@ -234,3 +234,74 @@ def test_saturation_pressure_increases_with_temperature():
     T = np.array([200., 220., 240., 260.])
     e = ContrailDrift._saturation_pressure_over_ice(T)
     assert np.all(np.diff(e) > 0), 'e_sat should increase with temperature'
+
+
+# ------------------------------------------------------------------ #
+# Schmidt-Appleman Criterion                                           #
+# ------------------------------------------------------------------ #
+
+def test_sac_critical_temperature_physical_range():
+    """T_SAC at 10 km (~26 500 Pa) should be ~230 K (physically reasonable)."""
+    # Mixing-line slope at 10 km with default parameters
+    eta, EI_H2O, Q = 0.30, 1.25, 43.2e6
+    p = 101325.0 * (1.0 - 2.2557e-5 * 10_000) ** 5.2559  # ≈ 26 500 Pa
+    G = 1004.0 * p * EI_H2O / (0.622 * Q * (1.0 - eta))
+    T_SAC = ContrailDrift._sac_critical_temperature(np.array([G]))
+    # T_SAC should be around 226-238 K for typical cruise conditions
+    assert 220.0 <= T_SAC[0] <= 245.0, f'T_SAC={T_SAC[0]:.1f} K out of range'
+
+
+def test_sac_critical_temperature_increases_with_pressure():
+    """Higher pressure → larger G → higher T_SAC → contrails harder to form."""
+    G_low  = 1004.0 * 20_000.0 * 1.25 / (0.622 * 43.2e6 * 0.7)
+    G_high = 1004.0 * 50_000.0 * 1.25 / (0.622 * 43.2e6 * 0.7)
+    T_low  = ContrailDrift._sac_critical_temperature(np.array([G_low]))
+    T_high = ContrailDrift._sac_critical_temperature(np.array([G_high]))
+    assert T_high[0] > T_low[0], 'T_SAC should increase with pressure/G'
+
+
+def test_sac_deactivates_warm_elements():
+    """Elements in warm air (T > T_SAC) should be deactivated with 'no_contrail'."""
+    c = ContrailDrift(loglevel=50)
+    # Warm air: at 5 km, G is large and T_SAC ≈ 245 K; 270 K >> T_SAC
+    c.set_config('environment:constant:x_wind', 0)
+    c.set_config('environment:constant:y_wind', 0)
+    c.set_config('environment:constant:air_temperature', 270)   # very warm
+    c.set_config('environment:constant:specific_humidity', 1e-5)
+    c.set_config('environment:constant:horizontal_diffusivity', 0)
+    c.seed_elements(
+        lon=np.linspace(0, 5, 10),
+        lat=np.full(10, 50.),
+        z=5_000,    # 5 km – T_SAC ≈ 245 K < 270 K → no contrails
+        time=datetime(2024, 1, 1),
+        ice_water_path=1e-4)
+    # All elements deactivate on the first step → OpenDrift raises ValueError
+    with pytest.raises(ValueError, match='stopped'):
+        c.run(duration=timedelta(minutes=5), time_step=60)
+
+    assert c.num_elements_active() == 0, (
+        'All elements should be deactivated: T=270 K > T_SAC at 5 km')
+    assert 'no_contrail' in c.status_categories
+
+
+def test_sac_keeps_cold_elements():
+    """Elements in cold air (T < T_SAC) should NOT be deactivated by SAC."""
+    c = ContrailDrift(loglevel=50)
+    # Cold air: typical 10 km temperature ≈ 220 K; T_SAC ≈ 232 K → 220 K < T_SAC
+    c.set_config('environment:constant:x_wind', 0)
+    c.set_config('environment:constant:y_wind', 0)
+    c.set_config('environment:constant:air_temperature', 215)   # well below T_SAC
+    # Saturated w.r.t. ice so no sublimation: q ≈ 2e-5 at 215 K, 26 500 Pa
+    c.set_config('environment:constant:specific_humidity', 2e-5)
+    c.set_config('environment:constant:horizontal_diffusivity', 0)
+    c.seed_elements(
+        lon=np.linspace(0, 5, 10),
+        lat=np.full(10, 50.),
+        z=10_000,   # 10 km – T_SAC ≈ 232 K > 215 K → contrails persist
+        time=datetime(2024, 1, 1),
+        ice_water_path=1e-4)
+    c.run(duration=timedelta(minutes=10), time_step=60)
+
+    # At least some elements should remain active (SAC satisfied)
+    assert c.num_elements_active() > 0, (
+        'Elements should survive SAC check when T < T_SAC')


### PR DESCRIPTION
- [run-ex] Snoozing plotting tests until July, due to machine dependent tiny differences in cartopy output
- reader_from_url renamed to reader_from_urlpath, now accepting URI syntax like fsspec: <reader_name>://path?query  E.g. reader_copenicusmarine://cmems_mod_glo_phy_anfc_merged-uv_PT1H-i or reader_constant://?x_wind=3&y_wind=0
- Using full urlpath if no specific reader is requested
- [run-ex] Specifying reader_copernicusmarine for CMEMS products in data_sources.txt
- Added reader_earthaccess as wrapper around NASA earthaccess client
- Converting time to python datetime in seed_elements, to allow using other time formats for seeding
- Allowing >>> import opendrift; print(opendrift.versions())
- Add ContrailDrift model with AMS→BGO example
- Update AMS→BGO example to use NOAA GFS wind at 5 km
- contrail: add Schmidt-Appleman Criterion (SAC) deactivation, raise altitude to 10 km
