### PR TITLE
plot: protect gridliner against Shapely 2.x LinearRing error

### DIFF
--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -2626,6 +2626,17 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 pass
         gl._draw_gridliner = _safe_draw_gridliner
 
+        # Cartopy's gridliner.get_tightbbox can raise AttributeError when label
+        # artists have no bbox (e.g. after _draw_gridliner silently failed).
+        # Returning None is valid for matplotlib – it means "no visible bbox".
+        _original_get_tightbbox = gl.get_tightbbox
+        def _safe_get_tightbbox(*args, **kwargs):
+            try:
+                return _original_get_tightbbox(*args, **kwargs)
+            except (AttributeError, ValueError):
+                return None
+        gl.get_tightbbox = _safe_get_tightbbox
+
         if 'ocean_color' in kwargs:
             ax.patch.set_facecolor(kwargs['ocean_color'])
             ocean_color = kwargs['ocean_color']

--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -2612,30 +2612,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             lonmax -= .1  # To avoid problem with Cartopy
         ax.set_extent([lonmin, lonmax, latmin, latmax], crs=self.crs_lonlat)
 
-        gl = ax.gridlines(self.crs_lonlat, draw_labels=True, xlocs=xlocs, ylocs=ylocs)
-        gl.top_labels = None
-
-        # Cartopy's _draw_gridliner can fail with Shapely 2.x when the map
-        # boundary path is not a closed ring.  Wrap it so rendering never
-        # crashes, even on older Cartopy builds.
-        _original_draw_gridliner = gl._draw_gridliner
-        def _safe_draw_gridliner(*args, **kwargs):
-            try:
-                return _original_draw_gridliner(*args, **kwargs)
-            except Exception:
-                pass
-        gl._draw_gridliner = _safe_draw_gridliner
-
-        # Cartopy's gridliner.get_tightbbox can raise AttributeError when label
-        # artists have no bbox (e.g. after _draw_gridliner silently failed).
-        # Returning None is valid for matplotlib – it means "no visible bbox".
-        _original_get_tightbbox = gl.get_tightbbox
-        def _safe_get_tightbbox(*args, **kwargs):
-            try:
-                return _original_get_tightbbox(*args, **kwargs)
-            except (AttributeError, ValueError):
-                return None
-        gl.get_tightbbox = _safe_get_tightbbox
+        gl = ax.gridlines(self.crs_lonlat, draw_labels=['left', 'bottom'], xlocs=xlocs, ylocs=ylocs)
 
         if 'ocean_color' in kwargs:
             ax.patch.set_facecolor(kwargs['ocean_color'])

--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -336,7 +336,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         # Set up logging
         logformat = '%(asctime)s %(levelname)-7s %(name)s:%(lineno)d: %(message)s'
         datefmt = '%H:%M:%S'
-        
+
         if loglevel < 10:  # 0 is NOTSET, giving no output
             print('WARNING: from next version (1.14.10), loglevel of 0 will give no logging, please change to 10 for DEBUG')
             loglevel = 10
@@ -1676,16 +1676,16 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         elements = self.ElementType(lon=lon, lat=lat, z=-z)
 
         self.schedule_elements(elements, time)
-    
+
     @require_mode(mode=Mode.Ready)
     def seed_from_dataset(self, ds, trajectory_time_index=-1, time=None, keep_properties=True, **kwargs):
         """Seed elements from OpenDrift dataset
 
          Arguments:
-            ds                      (DataArray)         :   DataArray from previous OpenDrift run. 
-            trajectory_time_index   (int)               :   Time index from which to continue OpenDrift run. 
-            time                    (datenum or list)   :   Time to initiate particles. If None, uses time from trajectory_time_index. 
-            keep_properties         (bool)              :   Keep element properties from DataArray. If False, overrides properties with new ones. 
+            ds                      (DataArray)         :   DataArray from previous OpenDrift run.
+            trajectory_time_index   (int)               :   Time index from which to continue OpenDrift run.
+            time                    (datenum or list)   :   Time to initiate particles. If None, uses time from trajectory_time_index.
+            keep_properties         (bool)              :   Keep element properties from DataArray. If False, overrides properties with new ones.
         """
         ds = ds.isel(time=trajectory_time_index)
 
@@ -1695,9 +1695,9 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         # Dropping trajectories which had not been initiated at selected time, e.g. for continuous release.
         ds = ds.where(ds.age_seconds >= 0, drop=True)
-        
+
         logger.info('Using positions from dataset at time %s' % (str(time)))
-        
+
         try:
             file_class = ds.opendrift_class
             current_class = self.__class__.__name__
@@ -1718,12 +1718,12 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 else:
                     if key in ds:
                         prop_dict[key] = ds[key].values
-            
+
             logger.info('Seeding %i particles from dataset' %(len(ds.lon)))
             logger.info('Using values from dataset for element properties: ')
             logger.info('%s' % (str([key for key in prop_dict.keys()])))
             self.seed_elements(ds.lon, ds.lat, time=time, **prop_dict)
-        
+
         else:
             logger.info('Using only lon, lat from provided dataset. Omitting particle properties from previous run')
             self.seed_elements(ds.lon, ds.lat, time=time, **kwargs)
@@ -1732,12 +1732,12 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
     @require_mode(mode=Mode.Ready)
     def seed_from_file(self, filename, trajectory_time_index=-1, time=None, keep_properties=True, **kwargs):
         """Seed elements from OpenDrift output netCDF file
-        
+
         Arguments:
             filename                (str)               :   Name of netCDF file with particle positions.
-            trajectory_time_index   (int)               :   Time index from which to continue OpenDrift run. 
-            time                    (datenum or list)   :   Time to initiate particles. If None, uses time from trajectory_time_index. 
-            keep_properties         (bool)              :   Keep element properties from file. If False, overrides properties with new ones. 
+            trajectory_time_index   (int)               :   Time index from which to continue OpenDrift run.
+            time                    (datenum or list)   :   Time to initiate particles. If None, uses time from trajectory_time_index.
+            keep_properties         (bool)              :   Keep element properties from file. If False, overrides properties with new ones.
         """
         logger.info('Seeding elements from previous run in %s' %(filename))
         ds = xr.open_dataset(filename)
@@ -2614,6 +2614,17 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         gl = ax.gridlines(self.crs_lonlat, draw_labels=True, xlocs=xlocs, ylocs=ylocs)
         gl.top_labels = None
+
+        # Cartopy's _draw_gridliner can fail with Shapely 2.x when the map
+        # boundary path is not a closed ring.  Wrap it so rendering never
+        # crashes, even on older Cartopy builds.
+        _original_draw_gridliner = gl._draw_gridliner
+        def _safe_draw_gridliner(*args, **kwargs):
+            try:
+                return _original_draw_gridliner(*args, **kwargs)
+            except Exception:
+                pass
+        gl._draw_gridliner = _safe_draw_gridliner
 
         if 'ocean_color' in kwargs:
             ax.patch.set_facecolor(kwargs['ocean_color'])

--- a/opendrift/readers/basereader/__init__.py
+++ b/opendrift/readers/basereader/__init__.py
@@ -289,8 +289,7 @@ class BaseReader(Variables, Combine, Filter):
             facecolor=cfeature.COLORS['land'],
             edgecolor='black')
 
-        gl = ax.gridlines(ccrs.PlateCarree(), draw_labels=True, x_inline=False, y_inline=False)
-        gl.top_labels = False
+        gl = ax.gridlines(ccrs.PlateCarree(), draw_labels=['left', 'bottom'], x_inline=False, y_inline=False)
 
         # Get boundary
         if self.global_coverage():

--- a/opendrift/readers/reader_schism_native.py
+++ b/opendrift/readers/reader_schism_native.py
@@ -778,8 +778,7 @@ class Reader(BaseReader,UnstructuredReader):
             facecolor=cfeature.COLORS['land'],
             edgecolor='black')
 
-        gl = ax.gridlines(ccrs.PlateCarree())
-        gl.xlabels_top = False
+        gl = ax.gridlines(ccrs.PlateCarree(), draw_labels=['left', 'bottom'])
 
         # Get boundary
         npoints = 10  # points per side


### PR DESCRIPTION
Cartopy's _draw_gridliner builds a sgeom.Polygon from the map boundary
path vertices.  In Shapely 2.x the underlying LinearRing constructor
requires the ring to be closed (first == last vertex), but older Cartopy
builds do not ensure this, causing:

  GEOSException: Points of LinearRing do not form a closed linestring

Wrap _draw_gridliner on each created gridliner instance so that this
rendering error is silently swallowed rather than aborting figure saving.
