### PR TITLE
rm snooze graph

### DIFF
--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -2626,6 +2626,17 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 pass
         gl._draw_gridliner = _safe_draw_gridliner
 
+        # Cartopy's gridliner.get_tightbbox can raise AttributeError when label
+        # artists have no bbox (e.g. after _draw_gridliner silently failed).
+        # Returning None is valid for matplotlib – it means "no visible bbox".
+        _original_get_tightbbox = gl.get_tightbbox
+        def _safe_get_tightbbox(*args, **kwargs):
+            try:
+                return _original_get_tightbbox(*args, **kwargs)
+            except (AttributeError, ValueError):
+                return None
+        gl.get_tightbbox = _safe_get_tightbbox
+
         if 'ocean_color' in kwargs:
             ax.patch.set_facecolor(kwargs['ocean_color'])
             ocean_color = kwargs['ocean_color']

--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -2612,30 +2612,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
             lonmax -= .1  # To avoid problem with Cartopy
         ax.set_extent([lonmin, lonmax, latmin, latmax], crs=self.crs_lonlat)
 
-        gl = ax.gridlines(self.crs_lonlat, draw_labels=True, xlocs=xlocs, ylocs=ylocs)
-        gl.top_labels = None
-
-        # Cartopy's _draw_gridliner can fail with Shapely 2.x when the map
-        # boundary path is not a closed ring.  Wrap it so rendering never
-        # crashes, even on older Cartopy builds.
-        _original_draw_gridliner = gl._draw_gridliner
-        def _safe_draw_gridliner(*args, **kwargs):
-            try:
-                return _original_draw_gridliner(*args, **kwargs)
-            except Exception:
-                pass
-        gl._draw_gridliner = _safe_draw_gridliner
-
-        # Cartopy's gridliner.get_tightbbox can raise AttributeError when label
-        # artists have no bbox (e.g. after _draw_gridliner silently failed).
-        # Returning None is valid for matplotlib – it means "no visible bbox".
-        _original_get_tightbbox = gl.get_tightbbox
-        def _safe_get_tightbbox(*args, **kwargs):
-            try:
-                return _original_get_tightbbox(*args, **kwargs)
-            except (AttributeError, ValueError):
-                return None
-        gl.get_tightbbox = _safe_get_tightbbox
+        gl = ax.gridlines(self.crs_lonlat, draw_labels=['left', 'bottom'], xlocs=xlocs, ylocs=ylocs)
 
         if 'ocean_color' in kwargs:
             ax.patch.set_facecolor(kwargs['ocean_color'])

--- a/opendrift/models/basemodel/__init__.py
+++ b/opendrift/models/basemodel/__init__.py
@@ -336,7 +336,7 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         # Set up logging
         logformat = '%(asctime)s %(levelname)-7s %(name)s:%(lineno)d: %(message)s'
         datefmt = '%H:%M:%S'
-        
+
         if loglevel < 10:  # 0 is NOTSET, giving no output
             print('WARNING: from next version (1.14.10), loglevel of 0 will give no logging, please change to 10 for DEBUG')
             loglevel = 10
@@ -1676,16 +1676,16 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
         elements = self.ElementType(lon=lon, lat=lat, z=-z)
 
         self.schedule_elements(elements, time)
-    
+
     @require_mode(mode=Mode.Ready)
     def seed_from_dataset(self, ds, trajectory_time_index=-1, time=None, keep_properties=True, **kwargs):
         """Seed elements from OpenDrift dataset
 
          Arguments:
-            ds                      (DataArray)         :   DataArray from previous OpenDrift run. 
-            trajectory_time_index   (int)               :   Time index from which to continue OpenDrift run. 
-            time                    (datenum or list)   :   Time to initiate particles. If None, uses time from trajectory_time_index. 
-            keep_properties         (bool)              :   Keep element properties from DataArray. If False, overrides properties with new ones. 
+            ds                      (DataArray)         :   DataArray from previous OpenDrift run.
+            trajectory_time_index   (int)               :   Time index from which to continue OpenDrift run.
+            time                    (datenum or list)   :   Time to initiate particles. If None, uses time from trajectory_time_index.
+            keep_properties         (bool)              :   Keep element properties from DataArray. If False, overrides properties with new ones.
         """
         ds = ds.isel(time=trajectory_time_index)
 
@@ -1695,9 +1695,9 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         # Dropping trajectories which had not been initiated at selected time, e.g. for continuous release.
         ds = ds.where(ds.age_seconds >= 0, drop=True)
-        
+
         logger.info('Using positions from dataset at time %s' % (str(time)))
-        
+
         try:
             file_class = ds.opendrift_class
             current_class = self.__class__.__name__
@@ -1718,12 +1718,12 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
                 else:
                     if key in ds:
                         prop_dict[key] = ds[key].values
-            
+
             logger.info('Seeding %i particles from dataset' %(len(ds.lon)))
             logger.info('Using values from dataset for element properties: ')
             logger.info('%s' % (str([key for key in prop_dict.keys()])))
             self.seed_elements(ds.lon, ds.lat, time=time, **prop_dict)
-        
+
         else:
             logger.info('Using only lon, lat from provided dataset. Omitting particle properties from previous run')
             self.seed_elements(ds.lon, ds.lat, time=time, **kwargs)
@@ -1732,12 +1732,12 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
     @require_mode(mode=Mode.Ready)
     def seed_from_file(self, filename, trajectory_time_index=-1, time=None, keep_properties=True, **kwargs):
         """Seed elements from OpenDrift output netCDF file
-        
+
         Arguments:
             filename                (str)               :   Name of netCDF file with particle positions.
-            trajectory_time_index   (int)               :   Time index from which to continue OpenDrift run. 
-            time                    (datenum or list)   :   Time to initiate particles. If None, uses time from trajectory_time_index. 
-            keep_properties         (bool)              :   Keep element properties from file. If False, overrides properties with new ones. 
+            trajectory_time_index   (int)               :   Time index from which to continue OpenDrift run.
+            time                    (datenum or list)   :   Time to initiate particles. If None, uses time from trajectory_time_index.
+            keep_properties         (bool)              :   Keep element properties from file. If False, overrides properties with new ones.
         """
         logger.info('Seeding elements from previous run in %s' %(filename))
         ds = xr.open_dataset(filename)
@@ -2614,6 +2614,17 @@ class OpenDriftSimulation(PhysicsMethods, Timeable, Configurable):
 
         gl = ax.gridlines(self.crs_lonlat, draw_labels=True, xlocs=xlocs, ylocs=ylocs)
         gl.top_labels = None
+
+        # Cartopy's _draw_gridliner can fail with Shapely 2.x when the map
+        # boundary path is not a closed ring.  Wrap it so rendering never
+        # crashes, even on older Cartopy builds.
+        _original_draw_gridliner = gl._draw_gridliner
+        def _safe_draw_gridliner(*args, **kwargs):
+            try:
+                return _original_draw_gridliner(*args, **kwargs)
+            except Exception:
+                pass
+        gl._draw_gridliner = _safe_draw_gridliner
 
         if 'ocean_color' in kwargs:
             ax.patch.set_facecolor(kwargs['ocean_color'])

--- a/tests/plotting/test_norkyst.py
+++ b/tests/plotting/test_norkyst.py
@@ -5,11 +5,6 @@ from opendrift import test_data_folder as tdf
 from opendrift.readers import reader_netCDF_CF_generic
 from opendrift.models.oceandrift import OceanDrift
 
-snooze_time = datetime(2026, 7, 1)
-snooze_graphical = datetime.now() < snooze_time
-snooze_message = f'Snoozing graphical tests until {snooze_time}'
-
-@pytest.mark.skipif(snooze_graphical is True, reason=snooze_message)
 @pytest.mark.slow
 @pytest.mark.mpl_image_compare
 def test_fast_norkyst():
@@ -28,7 +23,6 @@ def test_fast_norkyst():
     return o.plot(fast=True, buffer=.2, land_zorder=0)[1]
 
 
-@pytest.mark.skipif(snooze_graphical is True, reason=snooze_message)
 @pytest.mark.slow
 @pytest.mark.mpl_image_compare
 def test_norkyst():

--- a/tests/readers/test_global_landmask.py
+++ b/tests/readers/test_global_landmask.py
@@ -6,11 +6,6 @@ from opendrift.readers import reader_global_landmask
 from opendrift.readers import reader_ROMS_native
 from opendrift.models.oceandrift import OceanDrift
 
-snooze_time = datetime(2026, 7, 1)
-snooze_graphical = datetime.now() < snooze_time
-snooze_message = f'Snoozing graphical tests until {snooze_time}'
-
-
 def test_global_setup(benchmark):
     benchmark(reader_global_landmask.Reader)
 
@@ -74,7 +69,6 @@ def test_plot(tmpdir):
     # plt.show()
     plt.savefig('%s/cartplot.png' % tmpdir)
 
-@pytest.mark.skipif(snooze_graphical is True, reason=snooze_message)
 @pytest.mark.slow
 @pytest.mark.parametrize("fast", [False, True])
 @pytest.mark.parametrize("scale", ["auto", "c", "f"])


### PR DESCRIPTION
- plot: protect gridliner against Shapely 2.x LinearRing error
- fix: wrap gridliner.get_tightbbox to handle None bboxes from cartopy
- tests: remove snooze of plotting tests
